### PR TITLE
fix(clickhouse-operator): orphan CRDs app before removal

### DIFF
--- a/operators/clickhouse-operator-crds.yaml
+++ b/operators/clickhouse-operator-crds.yaml
@@ -3,8 +3,7 @@ kind: Application
 metadata:
   name: clickhouse-operator-crds
   namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
+  finalizers: []
 spec:
   project: default
   destination:
@@ -12,7 +11,7 @@ spec:
     namespace: operators
   syncPolicy:
     automated:
-      prune: true
+      prune: false
       selfHeal: true
     syncOptions:
     - PruneLast=true

--- a/operators/clickhouse-operator.yaml
+++ b/operators/clickhouse-operator.yaml
@@ -18,11 +18,6 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
-  ignoreDifferences:
-  - group: apiextensions.k8s.io
-    kind: CustomResourceDefinition
-    managedFieldsManagers:
-    - kube-apiserver
   source:
     chart: altinity-clickhouse-operator
     repoURL: https://helm.altinity.com


### PR DESCRIPTION
## Summary
- Removes finalizer and disables prune on `clickhouse-operator-crds` app so it can be safely deleted in a follow-up without cascade-deleting the CRDs from the cluster
- Reverts the `ignoreDifferences` workaround on the main app — the CRD OutOfSync was caused by dual management, not apiserver field drift
- CRDs are already managed by the main helm chart's `crds/` directory as of 0.27.1

## Test plan
- [ ] Merge this PR, verify `clickhouse-operator-crds` app syncs with prune=false and no finalizer
- [ ] Verify CRDs remain in cluster and `clickhouse-operator` app stays Synced+Healthy
- [ ] Follow up with a second PR to delete `clickhouse-operator-crds.yaml`