### PR TITLE
feat: deploy SearXNG with OpenResty auth sidecar

### DIFF
--- a/docs/superpowers/plans/2026-06-30-searxng-mcp.md
+++ b/docs/superpowers/plans/2026-06-30-searxng-mcp.md
@@ -49,6 +49,19 @@ metadata:
     secret-generator.v1.mittwald.de/length: "64"
 type: Opaque
 ---
+# Metrics password — used as HTTP Basic Auth password for /metrics endpoint.
+# Also referenced by the ServiceMonitor's basicAuth config.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: searxng-metrics-password
+  namespace: default
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+type: Opaque
+---
 # SearXNG settings — secret_key is non-sensitive here (JSON API only, no web sessions).
 # Google and Bing disabled to avoid CAPTCHA risk on home IP.
 apiVersion: v1
@@ -63,6 +76,8 @@ data:
     general:
       debug: false
       instance_name: "searxng-private"
+      enable_metrics: true
+      open_metrics: "${SEARXNG_OPEN_METRICS}"
 
     server:
       limiter: false
@@ -219,6 +234,16 @@ spec:
               memory: 128Mi
         - name: searxng
           image: docker.io/searxng/searxng:latest
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: SEARXNG_OPEN_METRICS
+              valueFrom:
+                secretKeyRef:
+                  name: searxng-metrics-password
+                  key: password
           volumeMounts:
             - name: searxng-settings
               mountPath: /etc/searxng/settings.yml
@@ -266,9 +291,33 @@ spec:
       port: 443
       targetPort: 443
       protocol: TCP
+    - name: metrics
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
   selector:
     app.kubernetes.io/name: searxng
     app.kubernetes.io/component: searxng
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: searxng
+  namespace: default
+  labels:
+    release: prom
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: searxng
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      basicAuth:
+        password:
+          name: searxng-metrics-password
+          key: password
 ```
 
 - [ ] **Step 2: Apply the manifest**
@@ -324,12 +373,34 @@ Status (no token): 401
 Results: 10
 ```
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Verify Prometheus metrics endpoint**
+
+```bash
+CLUSTER_IP=$(kubectl get svc searxng -n default -o jsonpath='{.spec.clusterIP}')
+METRICS_PASS=$(kubectl get secret searxng-metrics-password -n default -o jsonpath='{.data.password}' | base64 -d)
+
+# Should return OpenMetrics text output (after running at least one search)
+curl -s --resolve "searxng.k8s.somemissing.info:8080:${CLUSTER_IP}" \
+  -u "prometheus:${METRICS_PASS}" \
+  "http://searxng.k8s.somemissing.info:8080/metrics" | head -20
+```
+
+Expected: Lines starting with `# HELP searxng_engines_` and `# TYPE searxng_engines_`.
+
+Verify the ServiceMonitor is picked up by Prometheus:
+
+```bash
+kubectl get servicemonitor searxng -n default
+```
+
+Expected: resource exists and shows the `searxng` ServiceMonitor.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 cd ~/Documents/workspace/infra/k8s-manifests/vmubtkube-a
 git add searxng.yaml
-git commit -m "feat: deploy SearXNG with OpenResty auth sidecar"
+git commit -m "feat: deploy SearXNG with OpenResty auth sidecar and Prometheus metrics"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
@@ -148,6 +148,41 @@ TOKEN=$(kubectl get secret searxng-bearer-token -n default -o jsonpath='{.data.v
 keyring set searxng bearer-token "$TOKEN"
 ```
 
+## Metrics / Monitoring
+
+SearXNG has a built-in OpenMetrics endpoint at `/metrics`, gated by `general.open_metrics` in `settings.yml`. When set to a non-empty string, that string becomes the HTTP Basic Auth password for the endpoint (username is ignored by SearXNG).
+
+### Enabling the endpoint
+
+A mittwald-generated Secret (`searxng-metrics-password`) provides a random password. It is injected into the SearXNG container as `SEARXNG_OPEN_METRICS` and referenced in `settings.yml` via env var substitution:
+
+```yaml
+general:
+  enable_metrics: true
+  open_metrics: "${SEARXNG_OPEN_METRICS}"
+```
+
+### Scrape path
+
+The `/metrics` endpoint is served by SearXNG on port 8080. The OpenResty sidecar does **not** need to proxy this — Prometheus scrapes port 8080 directly inside the cluster with basic auth. A second Service port (`metrics`, 8080) is exposed for this purpose.
+
+### ServiceMonitor
+
+A `ServiceMonitor` (label `release: prom`) selects on `app.kubernetes.io/name: searxng` and scrapes the `metrics` port with `basicAuth` referencing the `searxng-metrics-password` Secret. This follows the same pattern as other ServiceMonitors in the cluster (e.g. `thanos-receive-ingestor`, `snmp-exporter`, `arr`).
+
+### Metrics exposed
+
+All per-engine, labeled by `engine_name`:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `searxng_engines_response_time_total_seconds` | gauge | Average total response time |
+| `searxng_engines_response_time_processing_seconds` | gauge | Average processing time |
+| `searxng_engines_response_time_http_seconds` | gauge | Average HTTP response time |
+| `searxng_engines_result_count_total` | counter | Total results returned |
+| `searxng_engines_request_count_total` | counter | Total user requests |
+| `searxng_engines_reliability_total` | counter | Overall engine reliability |
+
 ## Out of Scope
 
 - Redis result caching (stateless is sufficient for this use case)

--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
   "kubernetes": {
     "managerFilePatterns": [
       "/^(fluentbit|immich|operators|thanos|woodpecker)/.+\\.yaml$/",
-      "/^(cloudflared|external-dns|fluentbit-syslog|hyperdx-clickhouse|hyperdx-mongo|jellyfin|kubernetes-event-exporter|mumble|prowlarr|python-envoy-authz|radarr|reloader|sabnzbd|selfoss|snmp-exporter|sonarr|vpa)\\.yaml$/",
+      "/^(cloudflared|external-dns|fluentbit-syslog|hyperdx-clickhouse|hyperdx-mongo|jellyfin|kubernetes-event-exporter|mumble|prowlarr|python-envoy-authz|radarr|reloader|sabnzbd|searxng|selfoss|snmp-exporter|sonarr|vpa)\\.yaml$/",
       "/^application\\.hyperdx\\.yaml$/",
       "/^vendored/contour/patch-.+\\.yaml$/"
     ]

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: searxng-bearer-token
+  namespace: default
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: token
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: searxng-metrics-password
+  namespace: default
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "32"
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: searxng-secret-key
+  namespace: default
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: secret-key
+    secret-generator.v1.mittwald.de/encoding: hex
+    secret-generator.v1.mittwald.de/length: "64"
+type: Opaque
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: searxng-settings
+  namespace: default
+data:
+  settings.yml: |
+    use_default_settings: true
+
+    general:
+      debug: false
+      instance_name: "searxng-private"
+      enable_metrics: true
+      open_metrics: "METRICS_PASSWORD_PLACEHOLDER"
+
+    server:
+      limiter: false
+      image_proxy: false
+
+    search:
+      formats:
+        - json
+
+    engines:
+      - name: google
+        disabled: true
+      - name: google images
+        disabled: true
+      - name: google news
+        disabled: true
+      - name: google videos
+        disabled: true
+      - name: google scholar
+        disabled: true
+      - name: google play apps
+        disabled: true
+      - name: google play movies
+        disabled: true
+      - name: bing
+        disabled: true
+      - name: bing images
+        disabled: true
+      - name: bing news
+        disabled: true
+      - name: bing videos
+        disabled: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: searxng-nginx-config
+  namespace: default
+data:
+  nginx.conf: |
+    env BEARER_TOKEN;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        server {
+            listen 80;
+            server_name searxng.k8s.somemissing.info;
+
+            location / {
+                access_by_lua_block {
+                    local auth = ngx.req.get_headers()["Authorization"]
+                    if not auth then
+                        ngx.status = ngx.HTTP_UNAUTHORIZED
+                        ngx.header.content_type = "application/json"
+                        ngx.say('{"error":"missing Authorization header"}')
+                        return ngx.exit(ngx.HTTP_UNAUTHORIZED)
+                    end
+                    local token = auth:match("^Bearer (.+)$")
+                    if not token or token ~= os.getenv("BEARER_TOKEN") then
+                        ngx.status = ngx.HTTP_UNAUTHORIZED
+                        ngx.header.content_type = "application/json"
+                        ngx.say('{"error":"invalid token"}')
+                        return ngx.exit(ngx.HTTP_UNAUTHORIZED)
+                    end
+                }
+
+                proxy_pass http://localhost:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_read_timeout 30s;
+            }
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searxng
+  namespace: default
+  labels:
+    app.kubernetes.io/name: searxng
+    app.kubernetes.io/component: searxng
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: searxng
+      app.kubernetes.io/component: searxng
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: searxng
+        app.kubernetes.io/component: searxng
+    spec:
+      initContainers:
+        - name: inject-metrics-password
+          image: registry.apps.nickv.me/library/busybox:1.38.0
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              PASS=$(cat /run/secrets/metrics-password/password)
+              sed "s/METRICS_PASSWORD_PLACEHOLDER/$PASS/" \
+                /etc/searxng-template/settings.yml > /etc/searxng/settings.yml
+          volumeMounts:
+            - name: searxng-settings-template
+              mountPath: /etc/searxng-template
+              readOnly: true
+            - name: metrics-password
+              mountPath: /run/secrets/metrics-password
+              readOnly: true
+            - name: searxng-settings-rendered
+              mountPath: /etc/searxng
+      containers:
+        - name: openresty
+          image: registry.apps.nickv.me/openresty/openresty:1.31.1.1-alpine
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: searxng-bearer-token
+                  key: token
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /usr/local/openresty/nginx/conf/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+        - name: searxng
+          # renovate: datasource=docker depName=searxng/searxng versioning=regex:^(?<major>\d{4})\.(?<minor>\d+)\.(?<patch>\d+)-(?<build>[a-f0-9]+)$
+          image: registry.apps.nickv.me/searxng/searxng:2026.7.3-c5cd510d8
+          env:
+            - name: SEARXNG_PORT
+              value: "8080"
+            - name: SEARXNG_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: searxng-secret-key
+                  key: secret-key
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: searxng-settings-rendered
+              mountPath: /etc/searxng/settings.yml
+              subPath: settings.yml
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: searxng-nginx-config
+        - name: searxng-settings-template
+          configMap:
+            name: searxng-settings
+        - name: metrics-password
+          secret:
+            secretName: searxng-metrics-password
+        - name: searxng-settings-rendered
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: searxng
+  namespace: default
+  labels:
+    app.kubernetes.io/name: searxng
+    app.kubernetes.io/component: searxng
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: searxng.k8s.somemissing.info
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: metrics
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: searxng
+    app.kubernetes.io/component: searxng
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: searxng
+  namespace: default
+  labels:
+    release: prom
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: searxng
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      basicAuth:
+        password:
+          name: searxng-metrics-password
+          key: password


### PR DESCRIPTION
## Summary
- Deploy SearXNG to default namespace with OpenResty Lua bearer-token auth sidecar
- Prometheus metrics via built-in `/metrics` endpoint with ServiceMonitor + basicAuth
- All secrets (bearer token, metrics password, server secret_key) generated by mittwald
- Init container injects metrics password into settings.yml (SearXNG lacks env var support for `open_metrics`)
- Images pinned to specific versions and mirrored to `registry.apps.nickv.me`
- Renovate configured with regex versioning for SearXNG's `YYYY.M.D-hash` tag format
- No TLS — `k8s.somemissing.info` is delegated to OPNsense, not DnSimple

## Images mirrored
- `registry.apps.nickv.me/library/busybox:1.38.0`
- `registry.apps.nickv.me/openresty/openresty:1.31.1.1-alpine`
- `registry.apps.nickv.me/searxng/searxng:2026.7.3-c5cd510d8`

## Test plan
- [ ] Woodpecker CI mirrors all three images successfully
- [ ] `kubectl apply -f searxng.yaml` deploys without errors
- [ ] Bearer auth returns 401 without token, 200 with token
- [ ] `/metrics` endpoint returns OpenMetrics data with basic auth
- [ ] Renovate detects all three images for future updates