### PR TITLE
feat(ci): add Woodpecker vendir-sync step for PR branches

### DIFF
--- a/.ci/vendir-sync.sh
+++ b/.ci/vendir-sync.sh
@@ -1,31 +1,15 @@
 #!/bin/sh
 set -euo pipefail
 
-# Runs `vendir sync` on PR branches when vendir.yml or vendir.lock.yml changes,
-# then commits the updated vendored/*/base files back to the branch.
-# Woodpecker provides git credentials via CI_NETRC_* env vars.
+# Runs `vendir sync` on PR branches and commits the updated vendored/*/base
+# files back to the branch. The Woodpecker step's `path:` filter ensures this
+# only runs when vendir.yml or vendir.lock.yml actually changed.
 
-# Only act on PRs — push-to-main should already have synced files
-if [ "${CI_PIPELINE_EVENT}" != "pull_request" ]; then
-  echo "Not a PR event (${CI_PIPELINE_EVENT}), skipping."
-  exit 0
-fi
-
-# Check if vendir.yml or vendir.lock.yml changed in this PR
-TARGET_BRANCH="${CI_COMMIT_TARGET_BRANCH:-main}"
-git fetch origin "${TARGET_BRANCH}" --depth=1
-CHANGED_FILES=$(git diff --name-only "origin/${TARGET_BRANCH}...HEAD")
-
-if ! echo "${CHANGED_FILES}" | grep -qE '^vendir\.(yml|lock\.yml)$'; then
-  echo "No changes to vendir.yml or vendir.lock.yml, skipping."
-  exit 0
-fi
-
-echo "vendir.yml or vendir.lock.yml changed, running vendir sync..."
+echo "Running vendir sync..."
 vendir sync
 
 if git diff --quiet && git diff --cached --quiet; then
-  echo "vendir sync produced no changes."
+  echo "vendir sync produced no file changes."
   exit 0
 fi
 

--- a/.ci/vendir-sync.sh
+++ b/.ci/vendir-sync.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -euo pipefail
+
+# Runs `vendir sync` on PR branches when vendir.yml or vendir.lock.yml changes,
+# then commits the updated vendored/*/base files back to the branch.
+# Woodpecker provides git credentials via CI_NETRC_* env vars.
+
+# Only act on PRs — push-to-main should already have synced files
+if [ "${CI_PIPELINE_EVENT}" != "pull_request" ]; then
+  echo "Not a PR event (${CI_PIPELINE_EVENT}), skipping."
+  exit 0
+fi
+
+# Check if vendir.yml or vendir.lock.yml changed in this PR
+TARGET_BRANCH="${CI_COMMIT_TARGET_BRANCH:-main}"
+git fetch origin "${TARGET_BRANCH}" --depth=1
+CHANGED_FILES=$(git diff --name-only "origin/${TARGET_BRANCH}...HEAD")
+
+if ! echo "${CHANGED_FILES}" | grep -qE '^vendir\.(yml|lock\.yml)$'; then
+  echo "No changes to vendir.yml or vendir.lock.yml, skipping."
+  exit 0
+fi
+
+echo "vendir.yml or vendir.lock.yml changed, running vendir sync..."
+vendir sync
+
+if git diff --quiet && git diff --cached --quiet; then
+  echo "vendir sync produced no changes."
+  exit 0
+fi
+
+echo "Committing vendir sync results..."
+git config user.email "woodpecker@ci"
+git config user.name "Woodpecker CI"
+git add vendored/ vendir.lock.yml
+git commit -m "chore: vendir sync
+
+Co-authored-by: Woodpecker CI <woodpecker@ci>"
+
+# Push back to the PR branch
+git push origin "HEAD:${CI_COMMIT_SOURCE_BRANCH}"
+echo "Pushed vendir sync results to ${CI_COMMIT_SOURCE_BRANCH}."

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -31,12 +31,12 @@ steps:
         path:
           - "vendir.yml"
           - "vendir.lock.yml"
-    commands:
+    environment:
       # renovate: datasource=github-releases depName=carvel-dev/vendir
-      - >-
-        VENDIR_VERSION=v0.46.0 &&
-        wget -qO- "https://github.com/carvel-dev/vendir/releases/download/${VENDIR_VERSION}/vendir-linux-amd64" > /usr/local/bin/vendir &&
-        chmod +x /usr/local/bin/vendir
+      VENDIR_VERSION: v0.46.0
+    commands:
+      - wget -qO /usr/local/bin/vendir "https://github.com/carvel-dev/vendir/releases/download/$VENDIR_VERSION/vendir-linux-amd64"
+      - chmod +x /usr/local/bin/vendir
       - sh .ci/vendir-sync.sh
 
   mirror-images:

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -23,6 +23,21 @@ when:
     branch: main
 
 steps:
+  vendir-sync:
+    # renovate: datasource=docker depName=alpine/k8s
+    image: alpine/k8s:1.36.2
+    when:
+      - event: pull_request
+        path:
+          - "vendir.yml"
+          - "vendir.lock.yml"
+    commands:
+      # renovate: datasource=github-releases depName=carvel-dev/vendir
+      - VENDIR_VERSION=v0.46.0
+      - wget -qO- "https://github.com/carvel-dev/vendir/releases/download/${VENDIR_VERSION}/vendir-linux-amd64" > /usr/local/bin/vendir
+      - chmod +x /usr/local/bin/vendir
+      - sh .ci/vendir-sync.sh
+
   mirror-images:
     # renovate: datasource=docker depName=ghcr.io/regclient/regctl
     image: ghcr.io/regclient/regctl:v0.11.5-alpine

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -33,9 +33,10 @@ steps:
           - "vendir.lock.yml"
     commands:
       # renovate: datasource=github-releases depName=carvel-dev/vendir
-      - VENDIR_VERSION=v0.46.0
-      - wget -qO- "https://github.com/carvel-dev/vendir/releases/download/${VENDIR_VERSION}/vendir-linux-amd64" > /usr/local/bin/vendir
-      - chmod +x /usr/local/bin/vendir
+      - >-
+        VENDIR_VERSION=v0.46.0 &&
+        wget -qO- "https://github.com/carvel-dev/vendir/releases/download/${VENDIR_VERSION}/vendir-linux-amd64" > /usr/local/bin/vendir &&
+        chmod +x /usr/local/bin/vendir
       - sh .ci/vendir-sync.sh
 
   mirror-images:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -35,12 +35,6 @@ directories:
     path: .
   path: vendored/external-secrets-crds/base
 - contents:
-  - githubRelease:
-      tag: v0.8.1
-      url: https://api.github.com/repos/kubernetes-sigs/metrics-server/releases/281050386
-    path: .
-  path: vendored/metrics-server/base
-- contents:
   - git:
       commitTitle: 'Merge pull request #59 from nijave/dependabot/go_modules/sigs.k8s.io/controller-runtime-0.18.4...'
       sha: a3b9ab96e0f4b0c38b5cd53ed734e80fe3db8b4c
@@ -48,4 +42,10 @@ directories:
       - v0.3.2
     path: .
   path: vendored/kubelet-rubber-stamp/base
+- contents:
+  - githubRelease:
+      tag: v0.8.1
+      url: https://api.github.com/repos/kubernetes-sigs/metrics-server/releases/281050386
+    path: .
+  path: vendored/metrics-server/base
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
 minimumRequiredVersion: 0.40.0
 # Fetch whole upstream operator release bundles atomically. Renovate's vendir
-# manager bumps the tag/ref fields below, and postUpgradeTasks runs `vendir sync`
-# so the vendored/*/base files land in the same PR. Never hand-edit base/.
+# manager bumps the tag/ref fields below; Woodpecker CI runs `vendir sync` on
+# PR branches and commits the updated vendored/*/base files. Never hand-edit base/.
 directories:
   - path: vendored/cnpg/base
     contents:


### PR DESCRIPTION
## Summary
- Adds a `vendir-sync` Woodpecker CI step that runs `vendir sync` on PR branches when `vendir.yml` or `vendir.lock.yml` changes
- Commits updated `vendored/*/base` files and `vendir.lock.yml` back to the PR branch
- Ensures Renovate version bumps include the synced upstream manifests without requiring `postUpgradeTasks` (which is self-hosted only)
- Vendir binary version (`v0.46.0`) is tracked by Renovate via `github-releases` annotation
- Updates `vendir.yml` comment to reference Woodpecker CI instead of `postUpgradeTasks`

## Test plan
- [ ] Woodpecker pipeline triggers on this PR (vendir.yml changed)
- [ ] vendir-sync step runs successfully (or skips gracefully if no vendored content changes)
- [ ] mirror-images step still runs independently