### PR TITLE
feat(searxng): tune engines and timeouts for better result quality

### DIFF
--- a/docs/superpowers/plans/2026-06-30-searxng-mcp.md
+++ b/docs/superpowers/plans/2026-06-30-searxng-mcp.md
@@ -2,6 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Status: COMPLETED** — all four tasks implemented and merged to main in PR #177. The deployed version differs from the YAML/code embedded below in a few ways (plain HTTP on port 80 instead of TLS, initContainer-based metrics password injection, pinned private-registry images); `searxng.yaml` and `~/.local/lib/searxng-mcp/server.py` are the source of truth. See the design spec's "Implementation deviations" section.
+
+## Follow-up: result-quality tuning (2026-07-03)
+
+Applied after comparing result quality against Exa:
+
+- **Server-side** (`searxng.yaml` settings ConfigMap): raised `outgoing.request_timeout` to 5.0s with `retries: 1` (slow engines were silently dropped at the 3.0s default); enabled Mojeek and Qwant (+news variants); weighted Startpage 1.5 and Mojeek 1.2; added `hostnames` plugin config to boost github.com/stackoverflow.com and demote SEO farms.
+- **Client-side** (`server.py`): `search` gained `categories` (use `news` for current events), `time_range` (day/week/month/year), and `fetch_top` (inline extracted page text for the top N results, 8,000 chars each).
+
 **Goal:** Deploy SearXNG on local k8s and expose it as a Claude Code MCP tool so web search works when Z.ai's search quota is exhausted.
 
 **Architecture:** SearXNG runs in the `default` k8s namespace behind an OpenResty sidecar that terminates TLS and enforces a bearer token. A Python stdio MCP server on the host calls `https://searxng.k8s.somemissing.info` with the token from keyring and exposes `search` and `fetch` tools to Claude Code.

--- a/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
@@ -1,7 +1,14 @@
 # SearXNG MCP Server Design
 
 **Date:** 2026-06-30  
-**Status:** Approved
+**Status:** Implemented (merged in PR #177; result-quality tuning added 2026-07-03)
+
+## Implementation deviations from original design
+
+- The sidecar serves plain HTTP on port 80 (no TLS/cert-manager); traffic stays on the LAN via routable ClusterIP. `SEARXNG_URL` in the MCP server is `http://`.
+- The metrics password is injected by an initContainer that `sed`-replaces a placeholder in the settings template (SearXNG does not expand env vars in `settings.yml`).
+- Images are pulled through `registry.apps.nickv.me` rather than Docker Hub, and the SearXNG image is pinned (Renovate-managed) rather than `latest`.
+- `secret_key` comes from a mittwald-generated Secret via the `SEARXNG_SECRET` env var.
 
 ## Problem
 
@@ -33,12 +40,18 @@ Two auto-generated secrets via mittwald annotation:
 
 ### ConfigMap: SearXNG settings.yml
 
-SearXNG configured with safe engines only. Google disabled to avoid CAPTCHA risk on home IP. Enabled engines:
+SearXNG configured with safe engines only. Google and Bing disabled to avoid CAPTCHA risk on home IP. Enabled engines:
 
-- DuckDuckGo
+- DuckDuckGo (proxies Bing's index)
+- Startpage (proxies Google's index; weight 1.5 — best-quality results without scraping Google directly)
 - Brave Search
-- Wikipedia
-- Startpage
+- Mojeek (weight 1.2) and Qwant — independent indexes, scraping-tolerant (enabled 2026-07-03)
+- Wikipedia, GitHub, StackOverflow, MDN (SearXNG defaults)
+
+Result-quality tuning (2026-07-03):
+
+- `outgoing.request_timeout: 5.0` (default 3.0 silently dropped slow engines from responses), `max_request_timeout: 10.0`, `retries: 1`
+- `hostnames` plugin config: boosts `github.com`/`stackoverflow.com`, demotes SEO farms (Pinterest, Quora, Softonic)
 
 Conservative rate limiting. JSON API enabled. Web UI disabled (not needed, reduces attack surface). `secret_key` injected from Secret via env var.
 
@@ -98,9 +111,9 @@ ClusterIP on port 443, selector targets the Deployment. Routable from LAN/host v
 
 ### Tools exposed
 
-**`search(query: str, num_results: int = 10) -> list`**
+**`search(query: str, max_results: int = 10, categories: str = "", time_range: str = "", fetch_top: int = 0) -> list`**
 
-Calls `https://searxng.k8s.somemissing.info/search?q=<query>&format=json&num_results=<n>`. Returns a list of results, each with `title`, `url`, `content` (snippet), and `engine`. Strips any results with empty snippets.
+Calls `/search?q=<query>&format=json`, forwarding `categories` (general/news/it/images/videos/science/files/q&a) and `time_range` (day/week/month/year) when given — `categories=news` turns current-events queries from homepage links into dated articles. Returns a list of results, each with `title`, `url`, `content` (snippet), and `engine`. Strips any results with empty snippets. With `fetch_top=N`, the top N result pages are fetched and their extracted text inlined as `text` (max 8,000 chars each), closing the gap with content-extracting search APIs in a single call. (`categories`/`time_range`/`fetch_top` added 2026-07-03.)
 
 **`fetch(url: str) -> str`**
 

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -55,7 +55,41 @@ data:
       formats:
         - json
 
+    # Slower engines get dropped from responses at the default 3.0s timeout,
+    # shrinking result diversity
+    outgoing:
+      request_timeout: 5.0
+      max_request_timeout: 10.0
+      retries: 1
+
+    # Demote SEO farms; boost sources Claude Code queries most
+    hostnames:
+      high_priority:
+        - (.*\.)?github\.com$
+        - (.*\.)?stackoverflow\.com$
+      low_priority:
+        - (.*\.)?pinterest\.(com|co\.uk|fr|de)$
+        - (.*\.)?quora\.com$
+        - (.*\.)?softonic\.com$
+
     engines:
+      # Startpage proxies Google's index — best-quality results available
+      # without scraping Google directly
+      - name: startpage
+        weight: 1.5
+      - name: startpage news
+        weight: 1.5
+      # Mojeek and Qwant: independent indexes, scraping-tolerant
+      - name: mojeek
+        disabled: false
+        weight: 1.2
+      - name: mojeek news
+        disabled: false
+        weight: 1.2
+      - name: qwant
+        disabled: false
+      - name: qwant news
+        disabled: false
       - name: google
         disabled: true
       - name: google images


### PR DESCRIPTION
## Summary
Result-quality tuning for the SearXNG deployment, following a side-by-side comparison with Exa where SearXNG returned homepage links with thin snippets.

**Server-side (`searxng.yaml` settings ConfigMap):**
- Raise `outgoing.request_timeout` 3.0s → 5.0s with `retries: 1` — slow engines were silently dropped from responses at the default, shrinking result diversity
- Enable Mojeek and Qwant (+news variants) — independent, scraping-tolerant indexes
- Weight Startpage 1.5 (proxies Google's index) and Mojeek 1.2
- `hostnames` plugin config: boost github.com/stackoverflow.com, demote Pinterest/Quora/Softonic

Google/Bing remain disabled per the original design (home-IP CAPTCHA risk). Engine names and defaults verified against the deployed image's settings.yml (`c5cd510d8`).

**Docs:** design spec and plan marked implemented, with deviations from the original design recorded (HTTP:80, initContainer metrics-password injection, pinned private-registry images) and the client-side MCP server changes (`categories`/`time_range`/`fetch_top` params on `search`) documented.

Reloader restarts the pod on ConfigMap change after ArgoCD syncs.