### PR TITLE
feat(searxng): add Brave Search API engine with key from Bitwarden via ExternalSecret

### DIFF
--- a/docs/superpowers/plans/2026-06-30-searxng-mcp.md
+++ b/docs/superpowers/plans/2026-06-30-searxng-mcp.md
@@ -11,6 +11,10 @@ Applied after comparing result quality against Exa:
 - **Server-side** (`searxng.yaml` settings ConfigMap): raised `outgoing.request_timeout` to 5.0s with `retries: 1` (slow engines were silently dropped at the 3.0s default); enabled Mojeek and Qwant (+news variants); weighted Startpage 1.5 and Mojeek 1.2; added `hostnames` plugin config to boost github.com/stackoverflow.com and demote SEO farms.
 - **Client-side** (`server.py`): `search` gained `categories` (use `news` for current events), `time_range` (day/week/month/year), and `fetch_top` (inline extracted page text for the top N results, 8,000 chars each).
 
+## Follow-up: Brave Search API engine (2026-07-03)
+
+Added the official Brave Search API as a `braveapi` engine (weight 1.3, $5/mo free credit ≈ 1k queries). The key is stored in Bitwarden Secrets Manager as `searxng-braveapi-key`, synced into the cluster by an ExternalSecret (`searxng-engine-keys`, ClusterSecretStore `default`), and injected into settings.yml by the existing initContainer sed step. Google Programmable Search was rejected as a second API engine — Google removed whole-web search for new engines and is shutting down the Custom Search JSON API on 2027-01-01.
+
 **Goal:** Deploy SearXNG on local k8s and expose it as a Claude Code MCP tool so web search works when Z.ai's search quota is exhausted.
 
 **Architecture:** SearXNG runs in the `default` k8s namespace behind an OpenResty sidecar that terminates TLS and enforces a bearer token. A Python stdio MCP server on the host calls `https://searxng.k8s.somemissing.info` with the token from keyring and exposes `search` and `fetch` tools to Claude Code.

--- a/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
@@ -45,8 +45,11 @@ SearXNG configured with safe engines only. Google and Bing disabled to avoid CAP
 - DuckDuckGo (proxies Bing's index)
 - Startpage (proxies Google's index; weight 1.5 — best-quality results without scraping Google directly)
 - Brave Search
+- Brave Search API (`braveapi`, weight 1.3) — official API, independent index; key lives in Bitwarden Secrets Manager as `searxng-braveapi-key`, synced by an ExternalSecret into `searxng-engine-keys` and injected into settings.yml by the initContainer (added 2026-07-03). $5/mo free credit ≈ 1k queries.
 - Mojeek (weight 1.2) and Qwant — independent indexes, scraping-tolerant (enabled 2026-07-03)
 - Wikipedia, GitHub, StackOverflow, MDN (SearXNG defaults)
+
+Google Programmable Search was evaluated as a second API engine and rejected: Google removed "Search the entire web" for new engines (Jan 2026) and is discontinuing the Custom Search JSON API on 2027-01-01.
 
 Result-quality tuning (2026-07-03):
 

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -32,6 +32,29 @@ metadata:
     secret-generator.v1.mittwald.de/length: "64"
 type: Opaque
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: searxng-engine-keys
+  namespace: default
+spec:
+  refreshInterval: 300s
+  secretStoreRef:
+    name: default
+    kind: ClusterSecretStore
+  target:
+    template:
+      type: Opaque
+      data:
+        brave-api-key: "{{ .braveApiKey }}"
+  data:
+    - secretKey: braveApiKey
+      remoteRef:
+        key: searxng-braveapi-key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -73,6 +96,12 @@ data:
         - (.*\.)?softonic\.com$
 
     engines:
+      # Official Brave Search API (independent index) — key from Bitwarden
+      # via ExternalSecret; $5/mo free credit covers ~1k queries
+      - name: braveapi
+        inactive: false
+        api_key: "BRAVE_API_KEY_PLACEHOLDER"
+        weight: 1.3
       # Startpage proxies Google's index — best-quality results available
       # without scraping Google directly
       - name: startpage
@@ -186,7 +215,9 @@ spec:
           args:
             - |
               PASS=$(cat /run/secrets/metrics-password/password)
-              sed "s/METRICS_PASSWORD_PLACEHOLDER/$PASS/" \
+              BRAVE_KEY=$(cat /run/secrets/engine-keys/brave-api-key)
+              sed -e "s|METRICS_PASSWORD_PLACEHOLDER|$PASS|" \
+                  -e "s|BRAVE_API_KEY_PLACEHOLDER|$BRAVE_KEY|" \
                 /etc/searxng-template/settings.yml > /etc/searxng/settings.yml
           volumeMounts:
             - name: searxng-settings-template
@@ -194,6 +225,9 @@ spec:
               readOnly: true
             - name: metrics-password
               mountPath: /run/secrets/metrics-password
+              readOnly: true
+            - name: engine-keys
+              mountPath: /run/secrets/engine-keys
               readOnly: true
             - name: searxng-settings-rendered
               mountPath: /etc/searxng
@@ -270,6 +304,9 @@ spec:
         - name: metrics-password
           secret:
             secretName: searxng-metrics-password
+        - name: engine-keys
+          secret:
+            secretName: searxng-engine-keys
         - name: searxng-settings-rendered
           emptyDir: {}
 ---


### PR DESCRIPTION
## Summary
Adds the official Brave Search API as a SearXNG engine (`braveapi`, weight 1.3) — independent index, tops 2026 agentic-search benchmarks, and the Search plan's $5/mo free credit covers ~1k queries.

- **ExternalSecret** `searxng-engine-keys` pulls `searxng-braveapi-key` from Bitwarden Secrets Manager via the existing `default` ClusterSecretStore (same pattern as cloudflared/radarr)
- Key injected into `settings.yml` by the existing initContainer, switched to `|`-delimited sed so key characters can't break the substitution
- Reloader restarts the pod when the synced Secret changes

Google PSE was evaluated as a second API engine and rejected: Google removed "Search the entire web" for new engines (Jan 2026) and discontinues the Custom Search JSON API on 2027-01-01. Docs updated accordingly.

## Pre-merge requirement
The secret `searxng-braveapi-key` must exist in Bitwarden Secrets Manager (project `b6655361`) before merge, or the pod will wedge on the missing `searxng-engine-keys` mount.