### PR TITLE
feat(argocd): argocd-server serving cert via Let's Encrypt + DNS zone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ Manifests that *do* ship as Helm charts stay as ArgoCD Helm-source apps
 tracked by Renovate's `kubernetes` manager. Full design:
 `docs/superpowers/specs/2026-07-01-vendir-kustomize-design.md`.
 
+## DNS zones and TLS
+
+Two DNS zones, split by audience:
+
+- **`*.apps.somemissing.info`** — internet-facing services, exposed through
+  the Contour edge (HTTPProxy) with public DNS.
+- **`*.k8s.somemissing.info`** — internal/LAN-only services. These resolve to
+  routable ServiceIPs via the `external-dns.alpha.kubernetes.io/hostname`
+  annotation on a plain ClusterIP Service (external-dns writes the
+  `k8s.somemissing.info` zone over RFC2136) and are not reachable from the
+  internet.
+
+Both zones get **publicly-trusted Let's Encrypt certificates** from the
+`cert-manager-webhook-dnsimple-production` ClusterIssuer. DNS-01 validation
+has no reachability requirement, so internal-only `*.k8s` hostnames are
+issued the same way as public ones — no private CA to trust on clients. See
+`grafana.yaml` for a minimal example, or `proxy_argocd_webhook.yaml` for a
+cert consumed directly by the workload (`argocd-server-tls`).
+
+The private `k8s` CA in `clusterissuer.yaml` is **not** for browser-facing
+certs — it issues internal service-to-service certs (e.g.
+`python-envoy-authz`, validated by Contour via the delegated `k8s-ca`
+secret).
+
 ## Secret management
 
 Two mechanisms are available; pick by **where the secret originates**, not by

--- a/docs/superpowers/specs/2026-07-03-argocd-server-cert-design.md
+++ b/docs/superpowers/specs/2026-07-03-argocd-server-cert-design.md
@@ -1,0 +1,54 @@
+# ArgoCD server certificate via Let's Encrypt (dnsimple DNS-01)
+
+Date: 2026-07-03
+
+## Problem
+
+argocd-server serves a self-signed certificate that was silently regenerated
+when `argocd-secret` was recreated during the Helm→ArgoCD migration
+(2026-07-02). Direct access at `argocd.k8s.somemissing.info` (routable
+ServiceIP, external-dns annotation already on the `argocd-server` Service)
+gets a browser warning.
+
+## Decision
+
+One `Certificate` in the `argocd` namespace, matching the repo's established
+pattern for browser-facing services (grafana, woodpecker, otel-collector):
+
+- `secretName: argocd-server-tls` — ArgoCD's supported serving-cert override;
+  argocd-server watches this secret and hot-reloads it, replacing the
+  self-signed cert from `argocd-secret`. No restart, no Contour changes.
+- `issuerRef: ClusterIssuer cert-manager-webhook-dnsimple-production` —
+  Let's Encrypt via DNS-01.
+- `dnsNames`: `argocd.k8s.somemissing.info` (direct/LAN access) and
+  `argocd.apps.somemissing.info` (also valid if the public FQDN hits the pod
+  directly). In-cluster `*.svc` names are omitted — a public CA can't issue
+  them.
+
+Lives in `proxy_argocd_webhook.yaml` next to the other ArgoCD TLS resources.
+
+## Alternatives considered
+
+- **Private `k8s` CA** (exists in `clusterissuer.yaml`): rejected — it serves
+  as an internal service CA (only consumer: `python-envoy-authz`), and every
+  other `*.k8s.somemissing.info` UI uses publicly-trusted certs; a private
+  root would require trusting `k8s-ca` on every client device.
+- **Wildcard cert at Contour**: rejected in favor of the serving-cert
+  override; the webhook HTTPProxy keeps its existing edge cert.
+
+## DNS zone conventions (documented in README)
+
+- `*.apps.somemissing.info` — internet-facing services.
+- `*.k8s.somemissing.info` — internal/LAN services (routable ServiceIPs via
+  external-dns; not reachable from the internet).
+
+Both zones get publicly-trusted Let's Encrypt certs through the
+`cert-manager-webhook-dnsimple-production` ClusterIssuer (DNS-01 has no
+reachability requirement, so internal-only hostnames work fine).
+
+## Verification
+
+- Certificate becomes Ready; secret `argocd-server-tls` created.
+- `openssl s_client -connect argocd.k8s.somemissing.info:443` shows a Let's
+  Encrypt issuer and both SANs.
+- GitHub webhook delivery still returns 200; UI still reachable.

--- a/proxy_argocd_webhook.yaml
+++ b/proxy_argocd_webhook.yaml
@@ -30,6 +30,23 @@ spec:
           port: 443
           protocol: tls
 ---
+# Serving cert for argocd-server itself: ArgoCD watches the argocd-server-tls
+# secret and hot-reloads it in place of its generated self-signed cert.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-server-cert
+  namespace: argocd
+spec:
+  secretName: argocd-server-tls
+  issuerRef:
+    name: cert-manager-webhook-dnsimple-production
+    kind: ClusterIssuer
+  commonName: &cn argocd.k8s.somemissing.info
+  dnsNames:
+    - *cn
+    - argocd.apps.somemissing.info
+---
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Summary
- Add a cert-manager `Certificate` producing `argocd-server-tls` (ArgoCD's supported serving-cert override, hot-reloaded by argocd-server) from the `cert-manager-webhook-dnsimple-production` ClusterIssuer
- SANs: `argocd.k8s.somemissing.info` (LAN/ServiceIP access) and `argocd.apps.somemissing.info`
- Replaces the self-signed cert that was silently regenerated when `argocd-secret` was recreated during the Helm→ArgoCD migration
- Document the DNS zone conventions in the README: `*.apps.somemissing.info` = internet-facing, `*.k8s.somemissing.info` = internal/LAN; both use publicly-trusted LE certs via DNS-01
- Design notes in `docs/superpowers/specs/2026-07-03-argocd-server-cert-design.md`

## Verification plan (post-merge)
- Certificate Ready, `argocd-server-tls` secret created
- `openssl s_client -connect argocd.k8s.somemissing.info:443` shows LE issuer + both SANs
- GitHub webhook delivery still 200