### PR TITLE
feat(searxng): enable Marginalia engine with key from Bitwarden via ExternalSecret

### DIFF
--- a/docs/superpowers/plans/2026-06-30-searxng-mcp.md
+++ b/docs/superpowers/plans/2026-06-30-searxng-mcp.md
@@ -11,6 +11,10 @@ Applied after comparing result quality against Exa:
 - **Server-side** (`searxng.yaml` settings ConfigMap): raised `outgoing.request_timeout` to 5.0s with `retries: 1` (slow engines were silently dropped at the 3.0s default); enabled Mojeek and Qwant (+news variants); weighted Startpage 1.5 and Mojeek 1.2; added `hostnames` plugin config to boost github.com/stackoverflow.com and demote SEO farms.
 - **Client-side** (`server.py`): `search` gained `categories` (use `news` for current events), `time_range` (day/week/month/year), and `fetch_top` (inline extracted page text for the top N results, 8,000 chars each).
 
+## Follow-up: Marginalia engine (2026-07-03)
+
+Enabled the built-in `marginalia` engine (independent non-commercial-web index, uses `api2.marginalia-search.com`). Key comes from Bitwarden Secrets Manager as `searxng-marginalia-key` via the `searxng-engine-keys` ExternalSecret. The shared `public` key works as a rate-limited interim value; a free non-commercial key is issued by emailing contact@marginalia-search.com (see https://about.marginalia-search.com/article/api/). DuckDuckGo has no official search API (Instant Answers only); Kagi's Search API ($12/1k) noted as a possible future engine via json_engine.
+
 ## Follow-up: Brave Search API engine (2026-07-03)
 
 Added the official Brave Search API as a `braveapi` engine (weight 1.3, $5/mo free credit ≈ 1k queries). The key is stored in Bitwarden Secrets Manager as `searxng-braveapi-key`, synced into the cluster by an ExternalSecret (`searxng-engine-keys`, ClusterSecretStore `default`), and injected into settings.yml by the existing initContainer sed step. Google Programmable Search was rejected as a second API engine — Google removed whole-web search for new engines and is shutting down the Custom Search JSON API on 2027-01-01.

--- a/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
@@ -47,6 +47,7 @@ SearXNG configured with safe engines only. Google and Bing disabled to avoid CAP
 - Brave Search
 - Brave Search API (`braveapi`, weight 1.3) — official API, independent index; key lives in Bitwarden Secrets Manager as `searxng-braveapi-key`, synced by an ExternalSecret into `searxng-engine-keys` and injected into settings.yml by the initContainer (added 2026-07-03). $5/mo free credit ≈ 1k queries.
 - Mojeek (weight 1.2) and Qwant — independent indexes, scraping-tolerant (enabled 2026-07-03)
+- Marginalia — independent index of non-commercial/text-heavy web, complements SEO-buried technical content; free non-commercial API key by emailing contact@marginalia-search.com per https://about.marginalia-search.com/article/api/, stored in Bitwarden Secrets Manager as `searxng-marginalia-key` (added 2026-07-03)
 - Wikipedia, GitHub, StackOverflow, MDN (SearXNG defaults)
 
 Google Programmable Search was evaluated as a second API engine and rejected: Google removed "Search the entire web" for new engines (Jan 2026) and is discontinuing the Custom Search JSON API on 2027-01-01.

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -47,10 +47,17 @@ spec:
       type: Opaque
       data:
         brave-api-key: "{{ .braveApiKey }}"
+        marginalia-api-key: "{{ .marginaliaApiKey }}"
   data:
     - secretKey: braveApiKey
       remoteRef:
         key: searxng-braveapi-key
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: marginaliaApiKey
+      remoteRef:
+        key: searxng-marginalia-key
         conversionStrategy: Default
         decodingStrategy: None
         metadataPolicy: None
@@ -102,6 +109,13 @@ data:
         inactive: false
         api_key: "BRAVE_API_KEY_PLACEHOLDER"
         weight: 1.3
+      # Marginalia: independent index of non-commercial/text-heavy web —
+      # strong for technical blogs and docs buried by SEO on other engines.
+      # Free non-commercial key: https://about.marginalia-search.com/article/api/
+      - name: marginalia
+        inactive: false
+        disabled: false
+        api_key: "MARGINALIA_API_KEY_PLACEHOLDER"
       # Startpage proxies Google's index — best-quality results available
       # without scraping Google directly
       - name: startpage
@@ -216,8 +230,10 @@ spec:
             - |
               PASS=$(cat /run/secrets/metrics-password/password)
               BRAVE_KEY=$(cat /run/secrets/engine-keys/brave-api-key)
+              MARGINALIA_KEY=$(cat /run/secrets/engine-keys/marginalia-api-key)
               sed -e "s|METRICS_PASSWORD_PLACEHOLDER|$PASS|" \
                   -e "s|BRAVE_API_KEY_PLACEHOLDER|$BRAVE_KEY|" \
+                  -e "s|MARGINALIA_API_KEY_PLACEHOLDER|$MARGINALIA_KEY|" \
                 /etc/searxng-template/settings.yml > /etc/searxng/settings.yml
           volumeMounts:
             - name: searxng-settings-template


### PR DESCRIPTION
## Summary
Enables the built-in `marginalia` engine — an independent index of the non-commercial/text-heavy web (personal blogs, technical writing, docs), complementing the stack's weakest area: technical content buried by SEO farms on mainstream engines. The deployed SearXNG version already targets the new `api2.marginalia-search.com` endpoint.

- Second key (`searxng-marginalia-key`) added to the `searxng-engine-keys` ExternalSecret and injected via the initContainer, same pattern as the Brave key
- Engine enabled in `general` + `blogs` categories at default weight

## Pre-merge requirement
`searxng-marginalia-key` must exist in Bitwarden Secrets Manager **before merge** — a missing remoteRef fails the whole ExternalSecret sync (including the Brave key on future refreshes). The shared key `public` works as a rate-limited interim value; swap in a real key once issued (ESO refresh + Reloader handle the rollout automatically).

Free non-commercial key: email contact@marginalia-search.com per https://about.marginalia-search.com/article/api/