### PR TITLE
fix(cert-manager): pin DNS01 lookups to public resolvers

### DIFF
--- a/vendored/cert-manager/kustomization.yaml
+++ b/vendored/cert-manager/kustomization.yaml
@@ -6,3 +6,22 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base/cert-manager.yaml
+patches:
+  # k8s.somemissing.info is split-horizon: the LAN bind on opnsense is
+  # authoritative for it, but the public side lives flat in the
+  # somemissing.info zone at DNSimple. cert-manager's DNS01 zone walk must see
+  # the PUBLIC view or it resolves the zone as k8s.somemissing.info and the
+  # dnsimple webhook 404s. Pin all ACME DNS01 lookups to public resolvers.
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: cert-manager
+      namespace: cert-manager
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --dns01-recursive-nameservers-only


### PR DESCRIPTION
cert-manager's DNS01 SOA zone walk used cluster DNS, which randomly hits the split-horizon LAN view of k8s.somemissing.info (authoritative on opnsense) instead of the public view (flat records in the somemissing.info DNSimple zone). When it got the LAN view, the dnsimple webhook asked for zone `k8s.somemissing.info` → 404 (currently blocking `argocd-server-cert`; older `*.k8s` certs renewed only when the resolver coin flip landed on the public-recursing upstream).

Adds `--dns01-recursive-nameservers=1.1.1.1:53,8.8.8.8:53` and `--dns01-recursive-nameservers-only` to the vendored cert-manager controller via the existing kustomize overlay (JSON 6902, per the overlay's own guidance for args).