### PR TITLE
fix(cert-manager): restore --max-concurrent-challenges=5 dropped by vendir migration

### DIFF
--- a/vendored/cert-manager/kustomization.yaml
+++ b/vendored/cert-manager/kustomization.yaml
@@ -25,3 +25,16 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/args/-
         value: --dns01-recursive-nameservers-only
+  # Deliberate throttle from pre-vendir cert-manager.yaml (commit 6aa8707,
+  # 2025-11-16), dropped by the vendir migration. Upstream default is 60;
+  # base sets it explicitly at args index 4, so replace rather than append.
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: cert-manager
+      namespace: cert-manager
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/args/4
+        value: --max-concurrent-challenges=5


### PR DESCRIPTION
Migration-clobber audit follow-up. Commit 6aa8707 (2025-11-16) customized three cert-manager controller args; the vendir migration (c620973) silently reverted them to pristine upstream:

- `--dns01-recursive-nameservers` — restored in #186
- `--dns01-recursive-nameservers-only` — restored in #186
- `--max-concurrent-challenges=5` — restored here (base pins 60 explicitly at args index 4, so this is a JSON6902 `replace`)

Render verified with `kubectl kustomize vendored/cert-manager`. Note: if the upstream base ever reorders the controller args, the index-4 replace will need updating (kustomize will fail loudly, not silently, if the index disappears).