### PR TITLE
feat(searxng): terminate TLS on the OpenResty sidecar

### DIFF
--- a/docs/superpowers/plans/2026-06-30-searxng-mcp.md
+++ b/docs/superpowers/plans/2026-06-30-searxng-mcp.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Status: COMPLETED** — all four tasks implemented and merged to main in PR #177. The deployed version differs from the YAML/code embedded below in a few ways (plain HTTP on port 80 instead of TLS, initContainer-based metrics password injection, pinned private-registry images); `searxng.yaml` and `~/.local/lib/searxng-mcp/server.py` are the source of truth. See the design spec's "Implementation deviations" section.
+**Status: COMPLETED** — all four tasks implemented and merged to main in PR #177. The deployed version differs from the YAML/code embedded below in a few ways (initContainer-based metrics password injection, pinned private-registry images; TLS on 443 was deferred until `*.k8s.somemissing.info` issuance was fixed and restored 2026-07-03); `searxng.yaml` and `~/.local/lib/searxng-mcp/server.py` are the source of truth. See the design spec's "Implementation deviations" section.
 
 ## Follow-up: result-quality tuning (2026-07-03)
 

--- a/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
+++ b/docs/superpowers/specs/2026-06-30-searxng-mcp-design.md
@@ -5,7 +5,7 @@
 
 ## Implementation deviations from original design
 
-- The sidecar serves plain HTTP on port 80 (no TLS/cert-manager); traffic stays on the LAN via routable ClusterIP. `SEARXNG_URL` in the MCP server is `http://`.
+- ~~The sidecar serves plain HTTP on port 80 (no TLS/cert-manager)~~ Resolved 2026-07-03: with `*.k8s.somemissing.info` cert issuance fixed (PR #186), the sidecar now terminates TLS on 443 with a cert-manager Certificate as originally designed, and `SEARXNG_URL` is `https://`. Traffic stays on the LAN via routable ClusterIP.
 - The metrics password is injected by an initContainer that `sed`-replaces a placeholder in the settings template (SearXNG does not expand env vars in `settings.yml`).
 - Images are pulled through `registry.apps.nickv.me` rather than Docker Hub, and the SearXNG image is pinned (Renovate-managed) rather than `latest`.
 - `secret_key` comes from a mittwald-generated Secret via the `SEARXNG_SECRET` env var.

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -156,6 +156,20 @@ data:
       - name: bing videos
         disabled: true
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: searxng-k8s-somemissing-info-cert
+  namespace: default
+spec:
+  secretName: searxng-k8s-somemissing-info-tls
+  issuerRef:
+    name: cert-manager-webhook-dnsimple-production
+    kind: ClusterIssuer
+  commonName: &cn searxng.k8s.somemissing.info
+  dnsNames:
+    - *cn
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -171,8 +185,12 @@ data:
 
     http {
         server {
-            listen 80;
+            listen 443 ssl;
             server_name searxng.k8s.somemissing.info;
+
+            ssl_certificate /etc/nginx/tls/tls.crt;
+            ssl_certificate_key /etc/nginx/tls/tls.key;
+            ssl_protocols TLSv1.2 TLSv1.3;
 
             location / {
                 access_by_lua_block {
@@ -251,8 +269,8 @@ spec:
         - name: openresty
           image: registry.apps.nickv.me/openresty/openresty:1.31.1.1-alpine
           ports:
-            - name: http
-              containerPort: 80
+            - name: https
+              containerPort: 443
               protocol: TCP
           env:
             - name: BEARER_TOKEN
@@ -265,9 +283,12 @@ spec:
               mountPath: /usr/local/openresty/nginx/conf/nginx.conf
               subPath: nginx.conf
               readOnly: true
+            - name: tls
+              mountPath: /etc/nginx/tls
+              readOnly: true
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: 443
             initialDelaySeconds: 3
             periodSeconds: 5
           resources:
@@ -314,6 +335,9 @@ spec:
         - name: nginx-config
           configMap:
             name: searxng-nginx-config
+        - name: tls
+          secret:
+            secretName: searxng-k8s-somemissing-info-tls
         - name: searxng-settings-template
           configMap:
             name: searxng-settings
@@ -339,9 +363,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
-      port: 80
-      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
       protocol: TCP
     - name: metrics
       port: 8080


### PR DESCRIPTION
## Summary
`*.k8s.somemissing.info` cert issuance is fixed (#186), so this restores the original SearXNG design that was deferred at deploy time:

- cert-manager `Certificate` (`cert-manager-webhook-dnsimple-production` ClusterIssuer, same as grafana)
- OpenResty sidecar: `listen 443 ssl`, cert mounted at `/etc/nginx/tls`, probe/port moved to 443
- Service: `https` 443 (metrics 8080 unchanged; ServiceMonitor unaffected)
- MCP client (`server.py`, host-side) switched to `https://`; Let's Encrypt is publicly trusted so no CA config needed
- Design spec deviation marked resolved; plan doc + workstation note updated

## Rollout note
The pod will wait on the `searxng-k8s-somemissing-info-tls` secret until the Certificate is issued (~1-2 min for DNS01). The MCP client is already pointed at https, so searches fail for that window and recover.