### PR TITLE
fix(kured): raise reboot-pending alert threshold from 48h to 7d

### DIFF
--- a/kured.yaml
+++ b/kured.yaml
@@ -68,10 +68,10 @@ spec:
     rules:
     - alert: KuredRebootRequiredTooLong
       annotations:
-        summary: Node {{ $labels.node }} has had a pending reboot for over 48h.
-        description: kured has been signaling a required reboot on {{ $labels.node }} for more than 48h. Check the maintenance window, node drain blockers, or kured locks.
+        summary: Node {{ $labels.node }} has had a pending reboot for over 7d.
+        description: kured has been signaling a required reboot on {{ $labels.node }} for more than 7d, meaning at least one weekend maintenance window (Sat/Sun 04:00-08:00 ET) was missed. Check node drain blockers or kured locks.
       expr: max by (node) (kured_reboot_required) == 1
-      for: 48h
+      for: 7d
       labels:
         severity: warning
     - alert: KuredNodeStuckDraining


### PR DESCRIPTION
Reboots only happen in the Sat/Sun 04:00-08:00 ET window, so a sentinel appearing early in the week always exceeds 48h before the next window. 7d only fires if a full weekend window was actually missed.