### PR TITLE
feat(thanos): increase compact disk to 250Gi

### DIFF
--- a/thanos/thanos-compact-statefulSet.yaml
+++ b/thanos/thanos-compact-statefulSet.yaml
@@ -151,4 +151,4 @@ spec:
       storageClassName: zfs-generic-iscsi-csi
       resources:
         requests:
-          storage: 200Gi
+          storage: 250Gi


### PR DESCRIPTION
Compactor halted since June 18 after ENOSPC on the 200Gi volume. PVC already expanded live; this matches desired state to the cluster.