### PR TITLE
fix: scope event-exporter ClusterRole to events only

### DIFF
--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -9,8 +9,8 @@ kind: ClusterRole
 metadata:
   name: event-exporter
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
+- apiGroups: ["", "events.k8s.io"]
+  resources: ["events"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -41,6 +41,9 @@ data:
     logLevel: error
     logFormat: json
     metricsNamePrefix: event_exporter_
+    # RBAC is scoped to events only, so involved-object label/annotation
+    # lookups would 403; the stdout dump doesn't use them.
+    omitLookup: true
     leaderElection:
       enabled: true
     route:


### PR DESCRIPTION
## Summary
- Replace the wildcard ClusterRole rule (`apiGroups: ["*"], resources: ["*"], get/watch/list`) with read access to `events` in the core and `events.k8s.io` API groups only. The old rule let the event-exporter service account read every Secret in the cluster (DB passwords, restic keys, S3 creds).
- Add `omitLookup: true` to the exporter config so it stops trying to enrich events with involved-object labels/annotations, which the scoped RBAC would now 403. The stdout dump route doesn't reference labels, so no exported data downstream (HyperDX) depends on the lookup.

The leases rule for leader election is unchanged.

Found during an IaC best-practices review of the repo (highest-severity RBAC finding).