### PR TITLE
feat: add volsync restic backups for sabnzbd, jellyfin, mumble

### DIFF
--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -40,6 +40,71 @@ spec:
     requests:
       storage: 40Gi
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: restic-repo-jellyfin
+  namespace: media
+spec:
+  refreshInterval: 300s
+  secretStoreRef:
+    name: default
+    kind: ClusterSecretStore
+  target:
+    template:
+      type: Opaque
+      data:
+        RESTIC_REPOSITORY: s3:https://vmubthh01.s.nickv.me:/volsync-jellyfin
+        RESTIC_PASSWORD: "{{ .password }}"
+        AWS_ACCESS_KEY_ID: "{{ .accessKey }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secretKey }}"
+  data:
+  - secretKey: password
+    remoteRef:
+      key: volsync-restic-password-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+  - secretKey: accessKey
+    remoteRef:
+      key: volsync-restic-repo-id-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+  - secretKey: secretKey
+    remoteRef:
+      key: volsync-restic-repo-secret-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+---
+# Backs up the whole PVC including JELLYFIN_CACHE_DIR — volsync's restic
+# mover has no path excludes, so transcoding/image cache churn lands in
+# snapshots. Restic dedup keeps this tolerable.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: jellyfin-data
+  namespace: media
+spec:
+  sourcePVC: jellyfin-data
+  trigger:
+    schedule: "*/30 * * * *"
+  restic:
+    pruneIntervalDays: 14
+    repository: restic-repo-jellyfin
+    moverSecurityContext:
+      runAsUser: 1009
+      runAsGroup: 1001
+      fsGroup: 1001
+    retain:
+      hourly: 6
+      daily: 5
+      weekly: 4
+      monthly: 3
+      yearly: 0
+    copyMethod: Clone
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/mumble.yaml
+++ b/mumble.yaml
@@ -25,6 +25,68 @@ spec:
     requests:
       storage: 5Gi
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: restic-repo-mumble
+  namespace: default
+spec:
+  refreshInterval: 300s
+  secretStoreRef:
+    name: default
+    kind: ClusterSecretStore
+  target:
+    template:
+      type: Opaque
+      data:
+        RESTIC_REPOSITORY: s3:https://vmubthh01.s.nickv.me:/volsync-mumble
+        RESTIC_PASSWORD: "{{ .password }}"
+        AWS_ACCESS_KEY_ID: "{{ .accessKey }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secretKey }}"
+  data:
+  - secretKey: password
+    remoteRef:
+      key: volsync-restic-password-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+  - secretKey: accessKey
+    remoteRef:
+      key: volsync-restic-repo-id-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+  - secretKey: secretKey
+    remoteRef:
+      key: volsync-restic-repo-secret-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: mumble-data
+  namespace: default
+spec:
+  sourcePVC: mumble-data
+  trigger:
+    schedule: "*/30 * * * *"
+  restic:
+    pruneIntervalDays: 14
+    repository: restic-repo-mumble
+    moverSecurityContext:
+      runAsUser: 10000
+      runAsGroup: 10000
+      fsGroup: 10000
+    retain:
+      hourly: 6
+      daily: 5
+      weekly: 4
+      monthly: 3
+      yearly: 0
+    copyMethod: Clone
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/sabnzbd.yaml
+++ b/sabnzbd.yaml
@@ -40,6 +40,68 @@ spec:
     requests:
       storage: 40Gi
 ---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: restic-repo-sabnzbd
+  namespace: media
+spec:
+  refreshInterval: 300s
+  secretStoreRef:
+    name: default
+    kind: ClusterSecretStore
+  target:
+    template:
+      type: Opaque
+      data:
+        RESTIC_REPOSITORY: s3:https://vmubthh01.s.nickv.me:/volsync-sabnzbd
+        RESTIC_PASSWORD: "{{ .password }}"
+        AWS_ACCESS_KEY_ID: "{{ .accessKey }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .secretKey }}"
+  data:
+  - secretKey: password
+    remoteRef:
+      key: volsync-restic-password-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+  - secretKey: accessKey
+    remoteRef:
+      key: volsync-restic-repo-id-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+  - secretKey: secretKey
+    remoteRef:
+      key: volsync-restic-repo-secret-1
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: sabnzbd-data
+  namespace: media
+spec:
+  sourcePVC: sabnzbd-data
+  trigger:
+    schedule: "*/30 * * * *"
+  restic:
+    pruneIntervalDays: 14
+    repository: restic-repo-sabnzbd
+    moverSecurityContext:
+      runAsUser: 1002
+      runAsGroup: 1001
+      fsGroup: 1001
+    retain:
+      hourly: 6
+      daily: 5
+      weekly: 4
+      monthly: 3
+      yearly: 0
+    copyMethod: Clone
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Summary
Adds restic backups for the three config PVCs that had none, closing the gap with their already-backed-up siblings (radarr/sonarr/prowlarr/immich):

- **sabnzbd-data** (media) — repo `s3:...:/volsync-sabnzbd`, mover runs as 1002/1001 matching PUID/PGID
- **jellyfin-data** (media) — repo `s3:...:/volsync-jellyfin`, mover runs as 1009/1001 matching the pod securityContext. Note: volsync's restic mover has no path excludes, so the Jellyfin cache dir is included in snapshots; restic dedup keeps growth tolerable (comment in-file)
- **mumble-data** (default) — repo `s3:...:/volsync-mumble`, mover runs as 10000 matching the pod securityContext

All three follow the existing radarr pattern exactly: ExternalSecret from the shared `volsync-restic-*-1` credentials with a per-app repository path, `*/30 * * * *` schedule, 14d prune interval, 6h/5d/4w/3m retention, `copyMethod: Clone`.

Found during the repo IaC review (backup-gap findings).