### PR TITLE
fix: add resources and probes to external-dns, reduce log level

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -114,4 +114,28 @@ spec:
         - --source=contour-httpproxy
         - --publish-internal-services
         - --log-level
-        - debug
+        - info
+        ports:
+        - name: http
+          containerPort: 7979
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 256Mi


### PR DESCRIPTION
## Summary
- Add liveness + readiness probes on external-dns's built-in `:7979/healthz` endpoint (and declare the port). Previously a hung process was never restarted and DNS publishing stopped silently.
- Add `resources.requests` (10m CPU / 64Mi) with a 256Mi memory-only limit, matching the repo's newer convention of not setting CPU limits. The deployment was the only committed workload with no resources at all (BestEffort QoS — first to be evicted under node memory pressure).
- Change `--log-level` from `debug` to `info` — steady-state debug logging was just log-volume noise.

From the IaC review (reliability finding H1, task #2).