### PR TITLE
feat: validate manifests with kubeconform in CI

### DIFF
--- a/.ci/validate.sh
+++ b/.ci/validate.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -euo pipefail
+
+# Validates every manifest ArgoCD will apply, the same way ArgoCD renders it:
+#   1. hand-written manifests            -> kubeconform directly
+#   2. dirs with a kustomization.yaml    -> kustomize build | kubeconform
+#   3. vendored bases without an overlay -> kubeconform directly
+#
+# -skip CustomResourceDefinition: the strict schema set has no usable schema
+# for the CRD kind itself (kubernetes-json-schema gap); CRD contents are
+# upstream-generated anyway. The CRDs-catalog location validates our CRs
+# (Application, ExternalSecret, HTTPProxy, Cluster, VPA, ...).
+KUBECONFORM="kubeconform
+  -strict -summary
+  -skip CustomResourceDefinition
+  -schema-location default
+  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+echo "=== hand-written manifests ==="
+# Everything tracked except: vendored inputs (validated rendered below),
+# kustomize-rendered dirs, kustomization files themselves, and non-k8s YAML.
+git ls-files '*.yaml' \
+  | grep -vE '^(vendored/|fluentbit/|docs/|\.woodpecker\.yaml|renovate\.json|vendir)' \
+  | grep -v 'kustomization\.yaml' \
+  | xargs $KUBECONFORM
+
+echo "=== kustomize overlays ==="
+for kz in $(git ls-files '*/kustomization.yaml' | grep -v '/base/'); do
+  dir=$(dirname "$kz")
+  echo "--- $dir"
+  kustomize build "$dir" | $KUBECONFORM -
+done
+
+echo "=== plain vendored bases (no overlay) ==="
+for base in vendored/*/base; do
+  overlay=$(dirname "$base")
+  [ -f "$overlay/kustomization.yaml" ] && continue
+  echo "--- $base"
+  $KUBECONFORM "$base"/*.yaml
+done
+
+echo "All manifests valid."

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -23,6 +23,16 @@ when:
     branch: main
 
 steps:
+  validate:
+    # renovate: datasource=docker depName=alpine/k8s
+    image: alpine/k8s:1.36.2
+    environment:
+      # renovate: datasource=github-releases depName=yannh/kubeconform
+      KUBECONFORM_VERSION: v0.8.0
+    commands:
+      - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
+      - sh .ci/validate.sh
+
   vendir-sync:
     # renovate: datasource=docker depName=alpine/k8s
     image: alpine/k8s:1.36.2


### PR DESCRIPTION
## Summary
Task #1 from the IaC review: a single malformed YAML anywhere in the repo root fails the whole root Application render, and nothing gated it pre-merge.

New `validate` step (runs on all PRs + pushes to main, before vendir-sync/mirror-images):
- **Hand-written manifests** → `kubeconform -strict` directly
- **Kustomize overlays** (`vendored/*`, `fluentbit/`) → `kustomize build | kubeconform` — validating the rendered output exactly as ArgoCD applies it (this is why the metrics-server v1beta1→v1 PDB patch passes while the base alone wouldn't)
- **Plain vendored bases** (cnpg, barman-cloud-plugin, external-secrets-crds) → checked as-is
- CRs validate against the [datreeio CRDs-catalog](https://github.com/datreeio/CRDs-catalog) schemas (Application, ExternalSecret, HTTPProxy, CNPG Cluster, VPA, ReplicationSource, ...)
- `-skip CustomResourceDefinition`: known kubernetes-json-schema gap for the CRD kind itself; CRD bodies are upstream-generated

Validated locally: full repo passes (~530 resources, 0 invalid); a `replcias` typo test fails with exit 1 as expected. The kubeconform version is Renovate-tracked like vendir.