### PR TITLE
feat: pre-commit hook running the CI manifest validation

### DIFF
--- a/.ci/validate.sh
+++ b/.ci/validate.sh
@@ -34,7 +34,7 @@ echo "=== hand-written manifests ==="
 # Everything tracked except: vendored inputs (validated rendered below),
 # kustomize-rendered dirs, kustomization files themselves, and non-k8s YAML.
 git ls-files '*.yaml' \
-  | grep -vE '^(vendored/|fluentbit/|docs/|\.woodpecker\.yaml|renovate\.json|vendir)' \
+  | grep -vE '^(vendored/|fluentbit/|docs/|\.|renovate\.json|vendir)' \
   | grep -v 'kustomization\.yaml' \
   | xargs $KUBECONFORM
 

--- a/.ci/validate.sh
+++ b/.ci/validate.sh
@@ -16,6 +16,20 @@ KUBECONFORM="kubeconform
   -schema-location default
   -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
 
+# Cache downloaded schemas across runs (used by the pre-commit hook; CI pods
+# are ephemeral so caching there is pointless).
+if [ -n "${KUBECONFORM_CACHE:-}" ]; then
+  mkdir -p "$KUBECONFORM_CACHE"
+  KUBECONFORM="$KUBECONFORM -cache $KUBECONFORM_CACHE"
+fi
+
+# alpine/k8s ships a kustomize binary; local machines may only have kubectl.
+if command -v kustomize >/dev/null 2>&1; then
+  kustomize_build() { kustomize build "$1"; }
+else
+  kustomize_build() { kubectl kustomize "$1"; }
+fi
+
 echo "=== hand-written manifests ==="
 # Everything tracked except: vendored inputs (validated rendered below),
 # kustomize-rendered dirs, kustomization files themselves, and non-k8s YAML.
@@ -28,7 +42,7 @@ echo "=== kustomize overlays ==="
 for kz in $(git ls-files '*/kustomization.yaml' | grep -v '/base/'); do
   dir=$(dirname "$kz")
   echo "--- $dir"
-  kustomize build "$dir" | $KUBECONFORM -
+  kustomize_build "$dir" | $KUBECONFORM -
 done
 
 echo "=== plain vendored bases (no overlay) ==="

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Runs the same manifest validation as the CI validate step (.ci/validate.sh).
+# Setup:   pre-commit install
+# Needs:   kubeconform (https://github.com/yannh/kubeconform) and
+#          kustomize or kubectl on PATH.
+repos:
+  - repo: local
+    hooks:
+      - id: kubeconform-validate
+        name: kubeconform (same as CI validate step)
+        entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache sh .ci/validate.sh
+        language: system
+        types_or: [yaml]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Manifests that *do* ship as Helm charts stay as ArgoCD Helm-source apps
 tracked by Renovate's `kubernetes` manager. Full design:
 `docs/superpowers/specs/2026-07-01-vendir-kustomize-design.md`.
 
+## Manifest validation
+
+CI runs `.ci/validate.sh` (kubeconform, strict; overlays validated as
+`kustomize build` output) on every PR. To run the same check locally on each
+commit:
+
+```
+pre-commit install   # needs kubeconform and kustomize-or-kubectl on PATH
+```
+
+Schemas are cached under `.tmp/`, so repeat runs take ~2s.
+
 ## DNS zones and TLS
 
 Two DNS zones, split by audience:


### PR DESCRIPTION
## Summary
Stacked on #205 (targets its branch; GitHub retargets to main when it merges).

- `.pre-commit-config.yaml` with a single local hook calling **the same `.ci/validate.sh` CI runs** — one source of truth, no config drift between local and CI.
- `validate.sh` gains two local-friendly tweaks (no CI behavior change): an optional `KUBECONFORM_CACHE` (pre-commit sets it to `.tmp/kubeconform-cache`, already gitignored — repeat runs take ~1.6s) and a `kubectl kustomize` fallback when no standalone `kustomize` binary exists.
- README section documenting `pre-commit install` + the kubeconform/kustomize prerequisites.

Tested locally: `pre-commit run --all-files` passes; cached re-run 1.6s.