### PR TITLE
feat: render and validate Helm-source Applications in CI

### DIFF
--- a/.ci/validate-helm.sh
+++ b/.ci/validate-helm.sh
@@ -47,7 +47,13 @@ for f in application.*.yaml; do
   echo "--- $f ($chart@$version)"
   case "$repo" in
     http*) chart_ref="$chart"; repo_flag="--repo $repo" ;;
-    *)     chart_ref="oci://$repo/$chart"; repo_flag="" ;;
+    *)
+      # Pull OCI charts first and template the local tarball: some helm
+      # versions print registry pull chatter (Pulled:/Digest:) to stdout,
+      # which corrupts the piped manifest stream.
+      helm pull "oci://$repo/$chart" --version "$version" -d "$WORKDIR" >/dev/null
+      chart_ref="$WORKDIR/$chart-$version.tgz"; repo_flag=""
+      ;;
   esac
   # shellcheck disable=SC2086
   helm template "$release" "$chart_ref" $repo_flag \

--- a/.ci/validate-helm.sh
+++ b/.ci/validate-helm.sh
@@ -9,8 +9,28 @@ set -euo pipefail
 # --kube-version / --api-versions approximate the live cluster so charts that
 # gate on .Capabilities (e.g. VPA templates) render the same objects ArgoCD
 # applies. Bump KUBE_VERSION when the cluster upgrades.
-KUBE_VERSION="1.35"
-API_VERSIONS="--api-versions autoscaling.k8s.io/v1 --api-versions monitoring.coreos.com/v1"
+# Match the live cluster version (cukk auto-upgrades it); CI step pods can
+# GET /version via the default SA (system:public-info-viewer), local runs use
+# kubeconfig. Falls back to a pinned floor when no cluster is reachable.
+if [ -z "${KUBE_VERSION:-}" ]; then
+  KUBE_VERSION=$(kubectl version -o json 2>/dev/null | yq '.serverVersion.gitVersion // ""' || true)
+  KUBE_VERSION=${KUBE_VERSION#v}
+fi
+[ -n "$KUBE_VERSION" ] || { echo "WARNING: cluster version undetectable; using fallback"; KUBE_VERSION="1.35.0"; }
+echo "rendering against Kubernetes $KUBE_VERSION"
+
+# Discover the cluster's API versions (group/version plus group/version/Kind,
+# matching what ArgoCD passes) so .Capabilities-gated templates render exactly
+# what the cluster gets. Needs only the discovery endpoints, which
+# system:discovery grants to every authenticated principal — no extra RBAC.
+API_VERSIONS=$( {
+  kubectl api-versions 2>/dev/null
+  kubectl api-resources --no-headers 2>/dev/null | awk '{print $(NF-2)"/"$NF}'
+} | sort -u | sed 's/^/--api-versions /' | tr '\n' ' ' ) || true
+if [ -z "$API_VERSIONS" ]; then
+  echo "WARNING: API discovery unavailable; using fallback capability list"
+  API_VERSIONS="--api-versions autoscaling.k8s.io/v1 --api-versions monitoring.coreos.com/v1"
+fi
 
 # -ignore-missing-schemas: charts ship CRs of their own CRDs (rendered in the
 # same release) that the CRDs-catalog may not carry; missing-schema kinds are
@@ -19,6 +39,7 @@ KUBECONFORM="kubeconform
   -strict -summary
   -ignore-missing-schemas
   -skip CustomResourceDefinition
+  -kubernetes-version $KUBE_VERSION
   -schema-location default
   -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
 if [ -n "${KUBECONFORM_CACHE:-}" ]; then

--- a/.ci/validate-helm.sh
+++ b/.ci/validate-helm.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -euo pipefail
+
+# Renders every Helm-source Application the way ArgoCD does (helm template
+# with the app's valuesObject, release name, and namespace) and validates the
+# output with kubeconform. Catches chart/values mismatches, values.schema.json
+# violations, and template errors before ArgoCD hits them at sync time.
+#
+# --kube-version / --api-versions approximate the live cluster so charts that
+# gate on .Capabilities (e.g. VPA templates) render the same objects ArgoCD
+# applies. Bump KUBE_VERSION when the cluster upgrades.
+KUBE_VERSION="1.35"
+API_VERSIONS="--api-versions autoscaling.k8s.io/v1 --api-versions monitoring.coreos.com/v1"
+
+# -ignore-missing-schemas: charts ship CRs of their own CRDs (rendered in the
+# same release) that the CRDs-catalog may not carry; missing-schema kinds are
+# reported in the summary as skipped, not failed.
+KUBECONFORM="kubeconform
+  -strict -summary
+  -ignore-missing-schemas
+  -skip CustomResourceDefinition
+  -schema-location default
+  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+if [ -n "${KUBECONFORM_CACHE:-}" ]; then
+  mkdir -p "$KUBECONFORM_CACHE"
+  KUBECONFORM="$KUBECONFORM -cache $KUBECONFORM_CACHE"
+fi
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+APP_Q='select(.kind=="Application")'
+rendered=0
+for f in application.*.yaml; do
+  # Extract the Application doc first: applying `// {}` fallbacks directly to
+  # a multi-doc file emits one fallback per filtered-out document.
+  yq "$APP_Q" "$f" > "$WORKDIR/app.yaml"
+  chart=$(yq '.spec.source.chart // ""' "$WORKDIR/app.yaml")
+  [ -z "$chart" ] && continue   # git-source app; covered by validate.sh
+
+  repo=$(yq '.spec.source.repoURL' "$WORKDIR/app.yaml")
+  version=$(yq '.spec.source.targetRevision' "$WORKDIR/app.yaml")
+  release=$(yq '.spec.source.helm.releaseName // .metadata.name' "$WORKDIR/app.yaml")
+  namespace=$(yq '.spec.destination.namespace // "default"' "$WORKDIR/app.yaml")
+  yq '.spec.source.helm.valuesObject // {}' "$WORKDIR/app.yaml" > "$WORKDIR/values.yaml"
+
+  echo "--- $f ($chart@$version)"
+  case "$repo" in
+    http*) chart_ref="$chart"; repo_flag="--repo $repo" ;;
+    *)     chart_ref="oci://$repo/$chart"; repo_flag="" ;;
+  esac
+  # shellcheck disable=SC2086
+  helm template "$release" "$chart_ref" $repo_flag \
+    --version "$version" --namespace "$namespace" \
+    --values "$WORKDIR/values.yaml" --include-crds \
+    --kube-version "$KUBE_VERSION" $API_VERSIONS \
+    | $KUBECONFORM -
+  rendered=$((rendered + 1))
+done
+
+echo "All $rendered Helm applications rendered and validated."

--- a/.ci/validate.sh
+++ b/.ci/validate.sh
@@ -16,6 +16,21 @@ KUBECONFORM="kubeconform
   -schema-location default
   -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
 
+# Match validation to the live cluster version (cukk auto-upgrades the
+# cluster, so never hardcode it). Works in CI step pods via the default SA
+# (GET /version is allowed by system:public-info-viewer) and locally via
+# kubeconfig; falls back to master schemas when no cluster is reachable.
+if [ -z "${KUBE_VERSION:-}" ]; then
+  KUBE_VERSION=$(kubectl version -o json 2>/dev/null | yq '.serverVersion.gitVersion // ""' || true)
+  KUBE_VERSION=${KUBE_VERSION#v}
+fi
+if [ -n "$KUBE_VERSION" ]; then
+  echo "validating against Kubernetes $KUBE_VERSION"
+  KUBECONFORM="$KUBECONFORM -kubernetes-version $KUBE_VERSION"
+else
+  echo "WARNING: cluster version undetectable; validating against master schemas"
+fi
+
 # Cache downloaded schemas across runs (used by the pre-commit hook; CI pods
 # are ephemeral so caching there is pointless).
 if [ -n "${KUBECONFORM_CACHE:-}" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,11 @@ repos:
         language: system
         types_or: [yaml]
         pass_filenames: false
+      - id: helm-validate
+        name: helm render + kubeconform (same as CI validate-helm step)
+        entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache sh .ci/validate-helm.sh
+        language: system
+        # Chart downloads are slow; only fire when a Helm app (or the script)
+        # actually changed — mirrors the CI step's path gate. Needs helm + yq.
+        files: ^(application\..*\.yaml|\.ci/validate-helm\.sh)$
+        pass_filenames: false

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -33,6 +33,21 @@ steps:
       - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
       - sh .ci/validate.sh
 
+  validate-helm:
+    # renovate: datasource=docker depName=alpine/k8s
+    image: alpine/k8s:1.36.2
+    when:
+      - event: pull_request
+        path:
+          - "application.*.yaml"
+          - ".ci/validate-helm.sh"
+    environment:
+      # renovate: datasource=github-releases depName=yannh/kubeconform
+      KUBECONFORM_VERSION: v0.8.0
+    commands:
+      - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
+      - sh .ci/validate-helm.sh
+
   vendir-sync:
     # renovate: datasource=docker depName=alpine/k8s
     image: alpine/k8s:1.36.2


### PR DESCRIPTION
## Summary
Stacked on #206 (which stacks on #205) — merge in order; GitHub retargets bases automatically.

CI previously validated raw manifests and kustomize output, but the 20 Helm-source Applications rendered only at ArgoCD sync time. New `validate-helm` step:

- Extracts `chart`/`repoURL`/`targetRevision`/`releaseName`/`valuesObject`/destination namespace from each `application.*.yaml` (handles multi-doc files and OCI repos — `ghcr.io/metacontroller`, `registry-1.docker.io/bitnamicharts`)
- `helm template --include-crds` with `--kube-version 1.35` and `--api-versions` matching the cluster, so `.Capabilities`-gated templates (e.g. the VPA objects kube-prometheus/blackbox emit) render exactly what ArgoCD applies
- Validates rendered output with kubeconform (`-ignore-missing-schemas` for chart-own CRs; skips are counted in summaries, not silent)
- **Path-gated** to `application.*.yaml` / script changes — Renovate chart bumps trigger it, unrelated PRs skip the ~20 chart downloads

Tested locally: all 20 apps render and validate (exit 0); the run also exercises values.schema.json checks charts ship (helm template fails on violations).