### PR TITLE
fix: add PodDisruptionBudget for python-envoy-authz

### DIFF
--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -150,3 +150,13 @@ spec:
     caSecret: cert-manager/k8s-ca
     subjectName: python-envoy-authz
 ---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: python-envoy-authz
+  namespace: projectcontour
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: python-envoy-authz


### PR DESCRIPTION
Task #11 from the IaC review. The deployment already has required anti-affinity and full probes; the missing piece was a PDB — without it, draining multiple nodes (e.g. cukk rolling upgrades) can evict both replicas at once, taking down Contour's ext-authz path and with it auth for the proxied services. `minAvailable: 1` makes drains wait for a healthy replica.

Validated with .ci/validate.sh.