### PR TITLE
fix: add probes to fluent-bit-journald and event-exporter

### DIFF
--- a/fluentbit/conf/journald/fluent-bit.conf
+++ b/fluentbit/conf/journald/fluent-bit.conf
@@ -3,7 +3,15 @@
     Daemon        Off
     Log_Level     info
     Parsers_File  parsers.conf
-    HTTP_Server   Off
+    # Serve /api/v1/health for the liveness probe; reports unhealthy when
+    # error/retry-failure counts exceed the thresholds within the window.
+    HTTP_Server   On
+    HTTP_Listen   0.0.0.0
+    HTTP_Port     2020
+    Health_Check  On
+    HC_Errors_Count        5
+    HC_Retry_Failure_Count 5
+    HC_Period              60
 
 [INPUT]
     Name            systemd

--- a/fluentbit/journald-daemonset.yaml
+++ b/fluentbit/journald-daemonset.yaml
@@ -18,6 +18,16 @@ spec:
         - name: fluent-bit
           image: cr.fluentbit.io/fluent/fluent-bit:5.0
           args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          ports:
+            - name: http
+              containerPort: 2020
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
           securityContext:
             runAsUser: 0
             runAsGroup: 0

--- a/kubernetes-event-exporter.yaml
+++ b/kubernetes-event-exporter.yaml
@@ -95,6 +95,19 @@ spec:
         ports:
         - name: metrics
           containerPort: 2112
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - name: cfg
           mountPath: /data


### PR DESCRIPTION
Task #12 from the IaC review — the last two workloads shipping logs with no probes, where a hung process meant silent log loss until the 30-minute `*Down` alerts fired (and fluent-bit's wouldn't fire at all for a live-but-stuck pipeline).

**fluent-bit-journald** (DaemonSet):
- Enables the built-in HTTP server with `Health_Check On` (`HC_Errors_Count`/`HC_Retry_Failure_Count` 5 per 60s window) — `/api/v1/health` reports unhealthy on sustained output errors, so the liveness probe catches a wedged OTLP export pipeline, not just a dead process
- kustomize's configMapGenerator hash-suffix rolls the DaemonSet automatically on the config change

**kubernetes-event-exporter**:
- liveness + readiness on `/metrics:2112`; readiness also makes the existing `EventExporterDown` alert's `ready < spec` comparison meaningful

Validated with .ci/validate.sh (renders the fluentbit kustomization).