### PR TITLE
feat: pluto deprecated-API detection in CI and pre-commit

### DIFF
--- a/.ci/validate-helm.sh
+++ b/.ci/validate-helm.sh
@@ -47,6 +47,18 @@ if [ -n "${KUBECONFORM_CACHE:-}" ]; then
   KUBECONFORM="$KUBECONFORM -cache $KUBECONFORM_CACHE"
 fi
 
+# Also tee rendered output through pluto (deprecated/removed apiVersions in
+# the NEXT minor) when the binary is available — charts are the most likely
+# place a to-be-removed API hides.
+if command -v pluto >/dev/null 2>&1; then
+  PLUTO_TARGET="${PLUTO_TARGET:-$(echo "$KUBE_VERSION" | awk -F. '{printf "v%d.%d.0", $1, $2+1}')}"
+  echo "checking deprecations against Kubernetes $PLUTO_TARGET"
+  PLUTO="pluto detect - --ignore-deprecations --target-versions k8s=$PLUTO_TARGET"
+else
+  echo "WARNING: pluto not installed; skipping deprecation checks" >&2
+  PLUTO=""
+fi
+
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
 
@@ -80,8 +92,9 @@ for f in application.*.yaml; do
   helm template "$release" "$chart_ref" $repo_flag \
     --version "$version" --namespace "$namespace" \
     --values "$WORKDIR/values.yaml" --include-crds \
-    --kube-version "$KUBE_VERSION" $API_VERSIONS \
-    | $KUBECONFORM -
+    --kube-version "$KUBE_VERSION" $API_VERSIONS > "$WORKDIR/rendered.yaml"
+  $KUBECONFORM "$WORKDIR/rendered.yaml"
+  [ -n "$PLUTO" ] && $PLUTO < "$WORKDIR/rendered.yaml"
   rendered=$((rendered + 1))
 done
 

--- a/.ci/validate-pluto.sh
+++ b/.ci/validate-pluto.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -euo pipefail
+
+# Flags apiVersions that are deprecated or removed in the NEXT Kubernetes
+# minor, over the same manifest streams as .ci/validate.sh. kubeconform (which
+# validates against the CURRENT cluster version) only fails once an API is
+# already gone; cukk auto-upgrades the cluster, so this is the pre-upgrade
+# warning. Helm-rendered output is covered separately: .ci/validate-helm.sh
+# tees its streams through pluto when the binary is present.
+#
+# Policy: removals in the target version fail; deprecations are printed but
+# don't fail (--ignore-deprecations) — they have at least a release of runway.
+
+if ! command -v pluto >/dev/null 2>&1; then
+  echo "WARNING: pluto not installed; skipping deprecation checks" >&2
+  exit 0
+fi
+
+# Target the next minor above the live cluster version (see validate.sh for
+# why /version needs no extra RBAC). PLUTO_TARGET overrides, e.g. to test a
+# specific upgrade target.
+if [ -z "${PLUTO_TARGET:-}" ]; then
+  v=$(kubectl version -o json 2>/dev/null | yq '.serverVersion.gitVersion // ""' || true)
+  v=${v#v}
+  if [ -n "$v" ]; then
+    PLUTO_TARGET=$(echo "$v" | awk -F. '{printf "v%d.%d.0", $1, $2+1}')
+  else
+    echo "WARNING: cluster version undetectable; using pluto's default targets"
+    PLUTO_TARGET=""
+  fi
+fi
+[ -n "$PLUTO_TARGET" ] && echo "checking deprecations against Kubernetes $PLUTO_TARGET"
+
+PLUTO="pluto detect - --ignore-deprecations ${PLUTO_TARGET:+--target-versions k8s=$PLUTO_TARGET}"
+
+if command -v kustomize >/dev/null 2>&1; then
+  kustomize_build() { kustomize build "$1"; }
+else
+  kustomize_build() { kubectl kustomize "$1"; }
+fi
+
+echo "=== hand-written manifests ==="
+git ls-files '*.yaml' \
+  | grep -vE '^(vendored/|fluentbit/|docs/|\.|renovate\.json|vendir)' \
+  | grep -v 'kustomization\.yaml' \
+  | xargs awk 'FNR==1 && NR>1 {print "---"} {print}' | $PLUTO
+
+echo "=== kustomize overlays ==="
+for kz in $(git ls-files '*/kustomization.yaml' | grep -v '/base/'); do
+  dir=$(dirname "$kz")
+  echo "--- $dir"
+  kustomize_build "$dir" | $PLUTO
+done
+
+echo "=== plain vendored bases (no overlay) ==="
+for base in vendored/*/base; do
+  overlay=$(dirname "$base")
+  [ -f "$overlay/kustomization.yaml" ] && continue
+  echo "--- $base"
+  awk 'FNR==1 && NR>1 {print "---"} {print}' "$base"/*.yaml | $PLUTO
+done
+
+echo "No removed APIs for target version."

--- a/.ci/vendir-sync.sh
+++ b/.ci/vendir-sync.sh
@@ -5,6 +5,19 @@ set -euo pipefail
 # files back to the branch. The Woodpecker step's `path:` filter ensures this
 # only runs when vendir.yml or vendir.lock.yml actually changed.
 
+# Gating formerly done by the Woodpecker `when:` filter (the step must always
+# exist because mirror-images depends_on it — Woodpecker rejects DAG edges to
+# condition-filtered steps).
+if [ "${CI_PIPELINE_EVENT:-}" != "pull_request" ]; then
+  echo "Not a pull_request event; vendir sync only runs on PRs."
+  exit 0
+fi
+git fetch --quiet origin "${CI_COMMIT_TARGET_BRANCH:-main}"
+if git diff --quiet FETCH_HEAD -- vendir.yml vendir.lock.yml; then
+  echo "vendir.yml/vendir.lock.yml unchanged vs ${CI_COMMIT_TARGET_BRANCH:-main}; skipping sync."
+  exit 0
+fi
+
 echo "Running vendir sync..."
 vendir sync
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
-# Runs the same manifest validation as the CI validate step (.ci/validate.sh).
+# Runs the same manifest validation as the CI validate steps (.ci/validate*.sh).
 # Setup:   pre-commit install
-# Needs:   kubeconform (https://github.com/yannh/kubeconform) and
+# Needs:   kubeconform (https://github.com/yannh/kubeconform),
+#          pluto (https://github.com/FairwindsOps/pluto), and
 #          kustomize or kubectl on PATH.
 repos:
   - repo: local
@@ -8,6 +9,12 @@ repos:
       - id: kubeconform-validate
         name: kubeconform (same as CI validate step)
         entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache sh .ci/validate.sh
+        language: system
+        types_or: [yaml]
+        pass_filenames: false
+      - id: pluto-validate
+        name: pluto deprecated-API check (same as CI validate-pluto step)
+        entry: sh .ci/validate-pluto.sh
         language: system
         types_or: [yaml]
         pass_filenames: false

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -5,6 +5,11 @@
 #
 # Runs on PRs so Renovate's tag bumps mirror the new image before merge, and on
 # push to main as a self-healing backstop (re-mirrors anything missing).
+#
+# Step DAG (depends_on): validate, validate-pluto, and validate-helm run in
+# parallel from the start; vendir-sync waits for the steps that read
+# vendored/ (it rewrites those files in the shared workspace); mirror-images
+# waits for vendir-sync (it git-diffs the same workspace).
 clone:
   git:
     # renovate: datasource=docker depName=woodpeckerci/plugin-git
@@ -33,6 +38,16 @@ steps:
       - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
       - sh .ci/validate.sh
 
+  validate-pluto:
+    # renovate: datasource=docker depName=alpine/k8s
+    image: alpine/k8s:1.36.2
+    environment:
+      # renovate: datasource=github-releases depName=FairwindsOps/pluto
+      PLUTO_VERSION: v5.24.0
+    commands:
+      - wget -qO- "https://github.com/FairwindsOps/pluto/releases/download/$PLUTO_VERSION/pluto_$${PLUTO_VERSION#v}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin pluto
+      - sh .ci/validate-pluto.sh
+
   validate-helm:
     # renovate: datasource=docker depName=alpine/k8s
     image: alpine/k8s:1.36.2
@@ -44,13 +59,17 @@ steps:
     environment:
       # renovate: datasource=github-releases depName=yannh/kubeconform
       KUBECONFORM_VERSION: v0.8.0
+      # renovate: datasource=github-releases depName=FairwindsOps/pluto
+      PLUTO_VERSION: v5.24.0
     commands:
       - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
+      - wget -qO- "https://github.com/FairwindsOps/pluto/releases/download/$PLUTO_VERSION/pluto_$${PLUTO_VERSION#v}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin pluto
       - sh .ci/validate-helm.sh
 
   vendir-sync:
     # renovate: datasource=docker depName=alpine/k8s
     image: alpine/k8s:1.36.2
+    depends_on: [validate, validate-pluto]
     when:
       - event: pull_request
         path:
@@ -71,6 +90,7 @@ steps:
   mirror-images:
     # renovate: datasource=docker depName=ghcr.io/regclient/regctl
     image: ghcr.io/regclient/regctl:v0.11.5-alpine
+    depends_on: [vendir-sync]
     backend_options:
       kubernetes:
         hostUsers: false

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -69,12 +69,10 @@ steps:
   vendir-sync:
     # renovate: datasource=docker depName=alpine/k8s
     image: alpine/k8s:1.36.2
+    # No `when:` filter: mirror-images depends_on this step, and Woodpecker
+    # rejects a DAG whose dependency is filtered out by conditions. The
+    # equivalent gating (PR event + vendir file changes) lives in the script.
     depends_on: [validate, validate-pluto]
-    when:
-      - event: pull_request
-        path:
-          - "vendir.yml"
-          - "vendir.lock.yml"
     environment:
       # renovate: datasource=github-releases depName=carvel-dev/vendir
       VENDIR_VERSION: v0.46.0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CI runs `.ci/validate.sh` (kubeconform, strict; overlays validated as
 commit:
 
 ```
-pre-commit install   # needs kubeconform and kustomize-or-kubectl on PATH
+pre-commit install   # needs kubeconform, pluto, and kustomize-or-kubectl on PATH
 ```
 
 Schemas are cached under `.tmp/`, so repeat runs take ~2s.


### PR DESCRIPTION
TODO item 1. kubeconform validates against the *current* cluster version, so it only fails once an API is already removed; with cukk auto-upgrading the cluster, nothing warned ahead of time. Pluto ([FairwindsOps/pluto](https://github.com/FairwindsOps/pluto), Apache-2.0, actively maintained) fills that gap.

- **New `validate-pluto` step + `.ci/validate-pluto.sh`**: same manifest streams as `validate.sh` (hand-written, kustomize-rendered, plain vendored bases) piped through `pluto detect`, targeting **the next minor above the live cluster version** (1.35.6 → v1.36.0, auto-derived like KUBE_VERSION; `PLUTO_TARGET` overrides). Policy: removals fail, deprecations print but pass (`--ignore-deprecations`).
- **`validate-helm.sh` tees rendered charts** through the same check (renders once to a file; kubeconform + pluto both read it) — charts are the most likely place a to-be-removed API hides.
- **Parallel CI**: introduces the step DAG — `validate`/`validate-pluto`/`validate-helm` start concurrently; `vendir-sync` waits on the two steps that read `vendored/` from the shared workspace; `mirror-images` waits on `vendir-sync`.
- **pre-commit hook** running the same script (graceful skip with a warning when pluto isn't installed); README prerequisites updated.
- Pluto version is Renovate-tracked (`github-releases`), like kubeconform/vendir.

Tested locally: full repo passes (hooks ran on this commit; helm hook verified separately after a transient chart-repo timeout); a seeded `policy/v1beta1` PodSecurityPolicy fails with exit 4 as expected. Watch this PR's pipeline: first DAG-mode run — confirm parallel execution, and after merge confirm `mirror-images` still runs on push-to-main where `vendir-sync` is path-skipped.