### PR TITLE
perf: drop high-cardinality control-plane metrics from Thanos remote write

### DIFF
--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -202,6 +202,38 @@ spec:
                   # Require ; and at least 1 other character (both pod and server can't be empty)
                   regex: '.{2,};minio|scrapeConfig/minio-tenant/minio.*'
                   replacement: minio-default-minio-job
+                # Reduce Thanos Receive cardinality (~22% of stored series).
+                # Dropped from long-term storage only: local Prometheus keeps
+                # 7d of everything, so alerts and recording rules (including
+                # the apiserver SLO rules built on _bucket series) still
+                # evaluate normally and their aggregated outputs are written
+                # through to Thanos.
+                # apiserver/etcd classic-histogram buckets: keep _sum/_count
+                # (average latency survives); per-le percentile detail older
+                # than 7d is intentionally sacrificed.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'apiserver_(request_duration_seconds|request_body_size_bytes|request_sli_duration_seconds|response_sizes|watch_cache_read_wait_seconds|watch_list_duration_seconds|watch_events_sizes)_bucket'
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'etcd_request_duration_seconds_bucket'
+                # Constant feature-gate flags exported per control-plane
+                # process; pure noise in long-term storage.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'kubernetes_feature_enabled'
+                # kube-state-metrics per-pod detail with no query/alert use:
+                # tolerations is static spec data; status_reason is ~always 0
+                # (kube_pod_status_phase covers the useful signal).
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'kube_pod_(tolerations|status_reason)'
+                # etcd gRPC method x code explosion. Scoped by job because
+                # ArgoCD and Thanos expose the same metric name and those
+                # stay. etcd alerting evaluates on local Prometheus.
+                - action: drop
+                  sourceLabels: [__name__, job]
+                  regex: 'grpc_server_handled_total;kube-etcd'
             resources:
               limits:
                 memory: 4Gi


### PR DESCRIPTION
## Why

Series analysis of the Thanos Receive ingestors (via the TSDB status API on all 5 pods, all tenants) found **815k unique head series**, with the top offenders all control-plane telemetry:

| Family | Unique series |
|---|---|
| apiserver histogram `_bucket` (7 families) | ~126,600 |
| `etcd_request_duration_seconds_bucket` | 26,780 |
| `kubernetes_feature_enabled` | 10,900 |
| `kube_pod_status_reason` | 8,160 |
| `grpc_server_handled_total` (kube-etcd only) | ~4,400 |
| `kube_pod_tolerations` | 3,672 |

Ingestors have been OOM-killed at their 6Gi limit within the last 30 days, and head memory scales roughly linearly with series count. Measured against live data, these rules match **~89k logical series ≈ 535k stored series after ×2 HA senders and ×3 replication — about 22% of total ingest**.

## Design decisions

- **Remote-write drop, not scrape drop.** Local Prometheus keeps 7d of everything, so all kube-prometheus alerts and recording rules — including the apiserver SLO rules that consume `_bucket` series — evaluate unchanged, and their aggregated recording-rule outputs still flow to Thanos. Only raw long-term bucket detail is sacrificed.
- **Buckets only for histograms; `_sum`/`_count` kept** so long-term average latency remains queryable.
- **`grpc_server_handled_total` scoped to `job=kube-etcd`** — ArgoCD and Thanos components export the same metric name and are untouched.
- `kubernetes_feature_enabled` (constant per-process feature gates), `kube_pod_tolerations` (static spec data), and `kube_pod_status_reason` (~always 0; `kube_pod_status_phase` carries the signal) are dropped entirely.

## Verification

- YAML parses; rules land at `prometheusSpec.remoteWrite[0].writeRelabelConfigs` (6 rules incl. existing minio rewrite).
- Pre-commit kubeconform/pluto/helm-render hooks passed.
- Match counts verified against live Thanos data per rule.

Expected effect: ingestor head series drop from ~443k to ~350k per pod at the next head truncation cycle after sync; steady-state memory should follow roughly proportionally. Follow-ups tracked separately: 1h block duration, capnproto replication, router compression.