### PR TITLE
perf: drop one-hot pod conditions and workqueue buckets from remote write

### DIFF
--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -234,6 +234,21 @@ spec:
                 - action: drop
                   sourceLabels: [__name__, job]
                   regex: 'grpc_server_handled_total;kube-etcd'
+                # Pod ready/scheduled conditions are one-hot encoded (3
+                # series per pod: true/false/unknown). condition="true"
+                # alone carries the full signal (1=ready, 0=not);
+                # false is its complement and unknown is covered by
+                # kube_pod_status_phase{phase="Unknown"}.
+                - action: drop
+                  sourceLabels: [__name__, condition]
+                  regex: 'kube_pod_status_(ready|scheduled);(false|unknown)'
+                # Controller workqueue latency buckets (apiserver, KCM,
+                # scheduler, kubelet, argocd, external-secrets): keep
+                # _sum/_count for average latency; per-le percentile
+                # detail is not worth ~4k series per family long-term.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'workqueue_(queue|work)_duration_seconds_bucket'
             resources:
               limits:
                 memory: 4Gi


### PR DESCRIPTION
## What

Second cardinality pass after #212, adding two drop rules to the kube-prometheus → Thanos remote write:

1. **`kube_pod_status_{ready,scheduled}` with `condition="false"|"unknown"`** — these conditions are one-hot encoded: 3 series per pod, exactly one of which is 1. Keeping only `condition="true"` retains the full signal (1 = ready/scheduled, 0 = not) since `false` is its complement and `unknown` is also covered by `kube_pod_status_phase{phase="Unknown"}`. Dashboards/alerts almost universally query `condition="true"`. 3 → 1 series per pod for both metrics.
2. **`workqueue_{queue,work}_duration_seconds_bucket`** — controller queue-latency histograms, ~92% from apiserver/kube-controller-manager/scheduler/kubelet with small ArgoCD and external-secrets contributions. `_sum`/`_count` are kept (183 series each), so long-term average latency survives; only per-`le` percentile detail beyond local Prometheus's 7d retention is lost (same trade-off as the apiserver buckets in #212).

## Impact

Live match count: **~5.7k logical series** → ~34k stored series after ×2 HA senders and ×3 replication.

## Verification

- 8 relabel rules parse at `prometheusSpec.remoteWrite[0].writeRelabelConfigs`
- Pre-commit kubeconform/pluto/helm-render passed
- Match count verified against live Thanos data

Known trade-off: the Controller Manager Grafana dashboard's workqueue percentile panels will lack data older than 7d if queried through Thanos; averages remain available.