### PR TITLE
obs: expose democratic-csi controller sidecar metrics

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -106,6 +106,25 @@ spec:
       decodingStrategy: None
       metadataPolicy: None
 ---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: democratic-csi-controller
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: democratic-csi
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: democratic-csi
+      app.kubernetes.io/csi-role: controller
+  podMetricsEndpoints:
+    # chart doesn't declare container ports, so target by number
+    - portNumber: 8080 # external-provisioner
+    - portNumber: 8081 # external-attacher
+    - portNumber: 8082 # external-resizer
+    - portNumber: 8083 # external-snapshotter
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -147,6 +166,21 @@ spec:
           config:
             driver: ""
         controller:
+          # expose csi_sidecar_operations_seconds so controller-side CSI op
+          # latency (CreateVolume, DeleteVolume, snapshots) lands in Thanos;
+          # kubelet only covers node-side ops
+          externalProvisioner:
+            extraArgs:
+              - --http-endpoint=:8080
+          externalAttacher:
+            extraArgs:
+              - --http-endpoint=:8081
+          externalResizer:
+            extraArgs:
+              - --http-endpoint=:8082
+          externalSnapshotter:
+            extraArgs:
+              - --http-endpoint=:8083
           driver:
             image:
               # renovate: datasource=docker depName=democraticcsi/democratic-csi


### PR DESCRIPTION
## Why
Investigating democratic-csi slowness showed controller-side CSI latency is invisible: kubelet's `csi_operations_seconds` only covers node-side ops. Pairing request/response logs in HyperDX shows **CreateVolume averages ~14s** (p50 14s, max 25s over 48h), but there's no metric for it.

## What
- Enable `--http-endpoint` on the provisioner/attacher/resizer/snapshotter sidecars (ports 8080–8083)
- PodMonitor scraping them → `csi_sidecar_operations_seconds{method_name=...}` lands in Thanos

## Tracing
democratic-csi has **no OTEL/tracing support** (no otel deps in v1.9.5 or master), so sidecar metrics are the supported observability surface. Options if we want real traces later: fork the image with Node.js OTEL auto-instrumentation (`@opentelemetry/auto-instrumentations-node` instruments `@grpc/grpc-js`), or enable kubelet tracing.

Rendered against released chart 0.15.1 — 4 endpoints present; kubeconform/pluto pre-commit passed.