### PR TITLE
perf: third cardinality pass informed by Grafana Cloud allow lists

### DIFF
--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -249,6 +249,52 @@ spec:
                 - action: drop
                   sourceLabels: [__name__]
                   regex: 'workqueue_(queue|work)_duration_seconds_bucket'
+                # Third pass, informed by Grafana Cloud's Kubernetes
+                # Monitoring allow lists (grafana/k8s-monitoring-helm
+                # allowLists/): metrics their dashboards don't use and
+                # nothing here queries. Join/info metrics are deliberately
+                # KEPT even though Grafana drops them: kube_replicaset_owner
+                # (pod->deployment), node_disk_info (device identity),
+                # kube_persistentvolume_{info,claim_ref,capacity_bytes},
+                # device_udev_link_info. container_pressure_* (PSI) and
+                # container_oom_events_total are also kept intentionally.
+                # ReplicaSet spec/status duplicates deployment-level data
+                # and churns a full series set on every rollout.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'kube_replicaset_(created|metadata_generation|spec_replicas|status_(replicas|ready_replicas|fully_labeled_replicas|observed_generation|terminating_replicas))'
+                # Per-dataset ZIL transaction accounting; dataset I/O stats
+                # (nread/nwritten/reads/writes/nunlink*) are kept.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'node_zfs_zpool_dataset_zil_.*'
+                # Latency histogram buckets (probe, CRI, CSI ops); _sum and
+                # _count siblings are kept for averages.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: '(prober_probe_duration_seconds|kubelet_runtime_operations_duration_seconds|storage_operation_duration_seconds)_bucket'
+                # cadvisor detail beyond the working-set/usage/fs/network
+                # core: memory accounting internals, per-device blkio,
+                # process/thread/socket counts, spec mirrors, fs latency
+                # internals. container_fs_{reads,writes}(_bytes)_total and
+                # container_memory_{working_set,rss,cache,swap} etc stay.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'container_(blkio_device_usage_total|memory_failures_total|memory_max_usage_bytes|memory_failcnt|memory_kernel_usage|memory_total_(active|inactive)_file_bytes|memory_mapped_file|threads|threads_max|sockets|processes|ulimits_soft|cpu_load_d_average_10s|cpu_load_average_10s|cpu_(user|system)_seconds_total|last_seen|start_time_seconds|tasks_state|spec_.*|file_descriptors|fs_(usage_bytes|limit_bytes|inodes_.*|io_.*|read_seconds_total|write_seconds_total|sector_.*|(reads|writes)_merged_total))'
+                # node_disk detail: discard/flush/merged/queue-depth counters;
+                # core read/write bytes+time and node_disk_info (join) stay.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'node_disk_(discard.*|flush_requests.*|(reads|writes)_merged_total|io_now)'
+                # One-hot QoS class (5 series/pod, static) and PV metadata
+                # duplicated by kube_persistentvolume_info.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'kube_pod_status_qos_class|kube_persistentvolume_(created|volume_mode)'
+                # node-exporter self-telemetry and scheduler/thermal detail.
+                - action: drop
+                  sourceLabels: [__name__]
+                  regex: 'node_(scrape_collector_.*|cpu_scaling_governor|schedstat_.*|cooling_device_.*)'
             resources:
               limits:
                 memory: 4Gi


### PR DESCRIPTION
> Stacked on #213 (base set to its branch; GitHub will retarget to main when it merges).

## What

Cross-referenced everything we still store against **Grafana Cloud Kubernetes Monitoring's default allow lists** ([grafana/k8s-monitoring-helm `allowLists/`](https://github.com/grafana/k8s-monitoring-helm/tree/main/allowLists)) — the curated "what the standard dashboards actually use" sets for kube-state-metrics, kubelet, cadvisor, and node-exporter. 7 new drop rules for the intersection of "Grafana drops it" and "nothing here queries it":

| Group | Unique series |
|---|---|
| cadvisor detail (memory accounting internals, per-device blkio, threads/sockets/processes, spec mirrors, fs latency) | ~24,000 |
| ZFS per-dataset ZIL transaction accounting | ~17,300 |
| `kube_replicaset_*` spec/status (8 metrics — churn a full series set per rollout) | ~15,000 |
| `node_disk_*` discard/flush/merged/io_now | ~9,400 |
| probe/CRI/CSI latency `_bucket` (3 histograms; `_sum`/`_count` kept) | ~15,800 |
| `kube_pod_status_qos_class` + PV `created`/`volume_mode` | ~5,900 |
| node-exporter self-telemetry, schedstat, cooling, governor | ~4,900 |

## Deliberately kept where Grafana drops

- **`kube_replicaset_owner`** — pod→Deployment join path
- **`node_disk_info`** — device identity join (pairs with `device_udev_link_info`)
- **`kube_persistentvolume_{info,claim_ref,capacity_bytes}`** — PV↔PVC joins
- **`container_pressure_*`** (PSI) and **`container_oom_events_total`** — actively used for resource investigation
- **ZFS dataset I/O stats** (`nread`/`nwritten`/`reads`/`writes`/`nunlink*`)

## Impact

Live match: **~46.4k logical series** → ~93k unique (×2 HA senders) → ~280k stored (×3 replication), ≈14% of post-#213 ingest.
Cumulative over the three passes: **815k → ~545k unique series (-33%)**; ingestor head series ~443k → ~295k per pod expected.

## Verification

- 15 relabel rules parse at the correct path; pre-commit kubeconform/pluto/helm-render passed
- Every regex count-verified against live Thanos data
- Negative check: all keep-list metrics (joins, PSI, OOM, working-set/usage/fs/network core) verified unmatched by every rule