### PR TITLE
volsync: bump jellyfin restic cache to 4Gi

### DIFF
--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -93,6 +93,7 @@ spec:
   restic:
     pruneIntervalDays: 14
     repository: restic-repo-jellyfin
+    cacheCapacity: 4Gi
     moverSecurityContext:
       runAsUser: 1009
       runAsGroup: 1001


### PR DESCRIPTION
The jellyfin ReplicationSource uses volsync's default 1Gi `cacheCapacity`. Kubelet volume stats show the cache PVC peaked at **955Mi of ~973Mi usable** over the last 7 days — effectively full, so restic is likely re-fetching repo metadata each run (and risks failing as the repo grows). Every other cache PVC peaked ≤202Mi, so this is jellyfin-specific (churn-heavy repo, per the existing comment about JELLYFIN_CACHE_DIR landing in snapshots).

Bumps `cacheCapacity` to 4Gi. Note volsync won't resize the existing cache PVC in place; it may need the old `volsync-src-jellyfin-data-cache` PVC deleted so the next mover run recreates it at 4Gi.