### PR TITLE
perf: node-exporter drops for prometheus-ext; keep ZFS ZIL metrics

### DIFF
--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -263,11 +263,6 @@ spec:
                 - action: drop
                   sourceLabels: [__name__]
                   regex: 'kube_replicaset_(created|metadata_generation|spec_replicas|status_(replicas|ready_replicas|fully_labeled_replicas|observed_generation|terminating_replicas))'
-                # Per-dataset ZIL transaction accounting; dataset I/O stats
-                # (nread/nwritten/reads/writes/nunlink*) are kept.
-                - action: drop
-                  sourceLabels: [__name__]
-                  regex: 'node_zfs_zpool_dataset_zil_.*'
                 # Latency histogram buckets (probe, CRI, CSI ops); _sum and
                 # _count siblings are kept for averages.
                 - action: drop

--- a/prometheus-ext.yaml
+++ b/prometheus-ext.yaml
@@ -159,6 +159,23 @@ spec:
       maxBackoff: 500ms
       retryOnRateLimit: true
       sampleAgeLimit: 5m
+    # Same node-exporter drops as the kube-prometheus remote write (see
+    # application.kube-prometheus.yaml and
+    # docs/thanos-receive-memory-optimization.md). External ZFS hosts
+    # send these through this Prometheus, which the original rules did
+    # not cover. Kept: ZFS dataset I/O stats
+    # (nread/nwritten/reads/writes/nunlink*), node_disk_info (device
+    # identity join), core disk read/write bytes+time.
+    writeRelabelConfigs:
+    - action: drop
+      sourceLabels: [__name__]
+      regex: 'node_zfs_zpool_dataset_zil_.*'
+    - action: drop
+      sourceLabels: [__name__]
+      regex: 'node_disk_(discard.*|flush_requests.*|(reads|writes)_merged_total|io_now)'
+    - action: drop
+      sourceLabels: [__name__]
+      regex: 'node_(scrape_collector_.*|cpu_scaling_governor|schedstat_.*|cooling_device_.*)'
   serviceMonitorSelector:
     matchLabels:
       prometheus: ext

--- a/prometheus-ext.yaml
+++ b/prometheus-ext.yaml
@@ -159,17 +159,14 @@ spec:
       maxBackoff: 500ms
       retryOnRateLimit: true
       sampleAgeLimit: 5m
-    # Same node-exporter drops as the kube-prometheus remote write (see
-    # application.kube-prometheus.yaml and
-    # docs/thanos-receive-memory-optimization.md). External ZFS hosts
-    # send these through this Prometheus, which the original rules did
-    # not cover. Kept: ZFS dataset I/O stats
-    # (nread/nwritten/reads/writes/nunlink*), node_disk_info (device
-    # identity join), core disk read/write bytes+time.
+    # Node-exporter drops mirroring the kube-prometheus remote write
+    # (see application.kube-prometheus.yaml and
+    # docs/thanos-receive-memory-optimization.md). ZFS metrics
+    # (including ZIL detail) are deliberately NOT dropped here: this
+    # Prometheus scrapes the NAS, whose zpools have ZIL/SLOG worth
+    # observing. Kept: node_disk_info (device identity join), core
+    # disk read/write bytes+time.
     writeRelabelConfigs:
-    - action: drop
-      sourceLabels: [__name__]
-      regex: 'node_zfs_zpool_dataset_zil_.*'
     - action: drop
       sourceLabels: [__name__]
       regex: 'node_disk_(discard.*|flush_requests.*|(reads|writes)_merged_total|io_now)'


### PR DESCRIPTION
Gap found while validating the #215 rollout: node-exporter metrics from external hosts arrive via `prometheus-ext`, which had no `writeRelabelConfigs`.

Adds two drop rules to the ext remote write (node_disk discard/flush/merged/io_now detail, node-exporter self-telemetry/schedstat/cooling/governor) — ~6.3k logical series (~12.6k unique, ~38k stored).

**ZFS ZIL metrics are deliberately kept**: prometheus-ext scrapes the NAS, whose zpools have ZIL/SLOG worth observing. Since the k8s nodes run no ZFS at all, the zil drop rule added to kube-prometheus in #215 matched nothing — removed here rather than left as misleading dead config.