### PR TITLE
searxng: drop brave scraper, add web engines to it category

### DIFF
--- a/searxng.yaml
+++ b/searxng.yaml
@@ -113,6 +113,7 @@ data:
         inactive: false
         api_key: "BRAVE_API_KEY_PLACEHOLDER"
         weight: 1.3
+        categories: [general, it]
       # Marginalia: independent index of non-commercial/text-heavy web —
       # strong for technical blogs and docs buried by SEO on other engines.
       # Free non-commercial key: https://about.marginalia-search.com/article/api/
@@ -121,9 +122,11 @@ data:
         disabled: false
         api_key: "MARGINALIA_API_KEY_PLACEHOLDER"
       # Startpage proxies Google's index — best-quality results available
-      # without scraping Google directly
+      # without scraping Google directly. Also in `it` so category searches
+      # blend real web results with the docs/package engines
       - name: startpage
         weight: 1.5
+        categories: [general, it]
       - name: startpage news
         weight: 1.5
       # Mojeek and Qwant: independent indexes, scraping-tolerant
@@ -137,6 +140,20 @@ data:
         disabled: false
       - name: qwant news
         disabled: false
+      # DuckDuckGo stays enabled on purpose: with the bing engines disabled
+      # it's the only source of Bing-index results
+      - name: duckduckgo
+        disabled: false
+      # Brave scraper duplicates braveapi's index at 25% reliability and ~3s
+      # latency (vs 100% / 0.8s via the API) — keep only the keyed engine
+      - name: brave
+        disabled: true
+      - name: brave.images
+        disabled: true
+      - name: brave.videos
+        disabled: true
+      - name: brave.news
+        disabled: true
       - name: google
         disabled: true
       - name: google images


### PR DESCRIPTION
## Changes to the searxng-settings ConfigMap

1. **Disable the `brave` scraper engines** (`brave`, `brave.images`, `brave.videos`, `brave.news`). Instance metrics show the scraper duplicating the keyed `braveapi` engine's index at 25% reliability and ~2.9s HTTP latency (the slowest active engine, vs 100% / 0.8s for the API), while double-counting Brave results in result scoring/dedup.

2. **Add `startpage` and `braveapi` to the `it` category.** Per `/config`, `it` previously contained only docs/package engines (arch wiki, docker hub, gentoo, github, hoogle, mdn, mankier, pypi, stackoverflow, askubuntu, superuser), so `categories=it` searches from the MCP server returned Docker Hub / MDN noise for general technical queries. Both engines remain in `general`.

3. **Pin `duckduckgo` explicitly enabled** with a comment — with all `bing` engines disabled it's the only Bing-index source, so make that deliberate rather than a default-settings accident.

Verified against the live instance: engine names/categories confirmed via `/config`, brave scraper health via open_metrics, and the embedded settings.yml parses (kubeconform pre-commit passed). Reloader will roll the deployment on merge.