### PR TITLE
fix(thanos): raise compact memory limit to stop OOM crash loop

### DIFF
--- a/thanos/thanos-compact-statefulSet.yaml
+++ b/thanos/thanos-compact-statefulSet.yaml
@@ -61,7 +61,7 @@ spec:
         - --block-files-concurrency=2
         - --compact.concurrency=1
         - --compact.blocks-fetch-concurrency=2
-        - --downsample.concurrency=8
+        - --downsample.concurrency=2
         - --compact.enable-vertical-compaction
         # - --downsampling.disable
         - --deduplication.replica-label=prometheus_replica
@@ -108,10 +108,10 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 768Mi
+            memory: 2Gi
           requests:
             cpu: 100m
-            memory: 200Mi
+            memory: 512Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/compact


### PR DESCRIPTION
## Problem

`thanos-compact-0` is in an OOM crash loop: **42 restarts in 4 days**, exit code 137, container working set peaking at 765Mi against the 768Mi limit.

Memory follows a ~2h sawtooth (65Mi → ~700Mi → kill → restart). The last-state logs show it dies mid-downsample — a single 5m-resolution downsample of a 2-week block takes ~1h40m, so the compactor keeps redoing the same work and the downsampling backlog never drains.

## Fix

- Raise memory limit **768Mi → 2Gi** (the node running it has ~20Gi free) and bump the request 200Mi → 512Mi to match observed steady-state usage.
- Reduce `--downsample.concurrency` **8 → 2**: with the CPU limit at 1 core, 8-way downsample concurrency adds no throughput — it only multiplies peak memory.

`--enable-auto-gomemlimit` is already set, so GOMEMLIMIT scales with the new limit automatically.