### PR TITLE
fix(ci): mirror-images resolves annotated upstreams, ignores non-YAML diffs

### DIFF
--- a/.ci/mirror-images.sh
+++ b/.ci/mirror-images.sh
@@ -6,6 +6,9 @@
 #   - registryAliases["registry.apps.nickv.me"] -> default upstream registry
 #   - packageRules[].matchPackageNames + registryUrls -> per-image overrides
 #   - ignoreDeps -> mirror paths to skip (locally-built images)
+# plus `# renovate: ... registryUrl=<url> depName=<name>` annotations in the
+# manifests themselves (used where renovate's registryAliases can't express
+# the upstream, e.g. thanos/thanos living on quay.io).
 #
 # Convention assumed: the mirror path equals the upstream repo path, so e.g.
 # registry.apps.nickv.me/thanos/thanos is copied from quay.io/thanos/thanos.
@@ -67,6 +70,24 @@ jq -r '
   printf '%s %s\n' "$name" "$(strip_url "$url")"
 done > "$OVERRIDES"
 
+# Manifest annotations are a second override source: renovate rules that are
+# handled by the regex manager (e.g. thanos/thanos) carry their upstream in a
+# `# renovate: ... registryUrl=... depName=...` comment instead of
+# packageRules registryUrls. packageRules entries stay first in the file, so
+# they win the awk first-match lookup below.
+grep -rh --include='*.yaml' --include='*.yml' -E '#[[:space:]]*renovate:.*registryUrl=' . 2>/dev/null \
+  | awk '{
+      url = ""; name = ""
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^registryUrl=/) url = substr($i, 13)
+        if ($i ~ /^depName=/) name = substr($i, 9)
+      }
+      if (url != "" && name != "") print name, url
+    }' \
+  | sort -u | while read -r name url; do
+      printf '%s %s\n' "$name" "$(strip_url "$url")"
+    done >> "$OVERRIDES"
+
 jq -r '.ignoreDeps[]? // empty' "$RENOVATE_FILE" > "$IGNORE"
 
 # Pick a diff base appropriate for the trigger, then mirror refs found on
@@ -99,7 +120,9 @@ echo "diff base: $BASE_REF"
 # Detect git diff failure explicitly — without this, a missing merge-base
 # (e.g. shallow clone) silently produces empty $REFS and CI passes with
 # mirrored=0 failed=0, masking the failure.
-if ! git diff --unified=0 "$BASE_REF"...HEAD > "$RAW_DIFF" 2>&1; then
+# Restrict to YAML: docs (*.md) legitimately quote mirror refs in prose and
+# must not trigger mirroring.
+if ! git diff --unified=0 "$BASE_REF"...HEAD -- '*.yaml' '*.yml' > "$RAW_DIFF" 2>&1; then
   echo "ERROR: git diff against $BASE_REF failed:" >&2
   cat "$RAW_DIFF" >&2
   exit 1

--- a/.ci/mirror-images.sh
+++ b/.ci/mirror-images.sh
@@ -75,7 +75,9 @@ done > "$OVERRIDES"
 # `# renovate: ... registryUrl=... depName=...` comment instead of
 # packageRules registryUrls. packageRules entries stay first in the file, so
 # they win the awk first-match lookup below.
-grep -rh --include='*.yaml' --include='*.yml' -E '#[[:space:]]*renovate:.*registryUrl=' . 2>/dev/null \
+# git grep, not grep -r --include: the CI image's busybox grep lacks --include.
+# Returns 1 on no match, which is fine — guard so set -e doesn't kill us.
+{ git grep -h -E '#[[:space:]]*renovate:.*registryUrl=' -- '*.yaml' '*.yml' || true; } \
   | awk '{
       url = ""; name = ""
       for (i = 1; i <= NF; i++) {


### PR DESCRIPTION
## Problem

The `mirror-images` CI step is failing on PR #216 (docs runbook) and PR #222 (renovate thanos v0.42.0 bump), both with:

```
copy failed, error getting source: failed to request manifest head docker.io/thanos/thanos:v0.41.0: unauthorized
```

Two distinct bugs:

1. **Annotated upstreams not resolved.** The script builds its upstream-override map only from `packageRules[].registryUrls` in renovate.json. The thanos rule is `enabled: false` (handled by the regex manager), so its quay.io upstream lives only in the `# renovate: ... registryUrl=https://quay.io depName=thanos/thanos` manifest annotations — which the script ignored. It fell back to the default `index.docker.io`, where `thanos/thanos` doesn't exist. This breaks **every** thanos image change, including Renovate bumps.

2. **Docs trigger mirroring.** The added-lines grep ran over the entire diff, so PR #216's runbook quoting `registry.apps.nickv.me/thanos/thanos:v0.41.0` in prose triggered a mirror attempt. A docs-only PR should never mirror anything.

## Fix

- Parse `# renovate: ... registryUrl=... depName=...` annotations from `*.yaml`/`*.yml` into the override map. packageRules entries keep precedence (awk first-match).
- Restrict the added-lines diff to `*.yaml`/`*.yml`.

## Verification

- Annotation parse over the repo yields `thanos/thanos quay.io`.
- PR #216's diff restricted to YAML has zero added lines → no mirror attempted.
- `sh -n` passes.

After merge, re-running CI on #216 and #222 should go green (their merge refs pick up the fixed script from main).