### PR TITLE
democratic-csi: custom foreign-snapshots build, ignore foreign snapshots on DeleteVolume

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -47,6 +47,10 @@ spec:
           zfs:
             cli:
               sudoEnabled: true
+            # snapshots created outside democratic-csi (sanoid, etc) inherit
+            # democratic-csi:managed_resource and would block DeleteVolume forever;
+            # only snapshots with the property set locally/received count as managed
+            deleteVolumeIgnoreForeignSnapshots: true
           
             # can be used to set arbitrary values on the dataset/zvol
             # can use handlebars templates with the parameters from the storage class/CO
@@ -183,9 +187,10 @@ spec:
               - --http-endpoint=:8083
           driver:
             image:
-              # renovate: datasource=docker depName=democraticcsi/democratic-csi
-              registry: registry.apps.nickv.me/democraticcsi/democratic-csi
-              tag: v1.9.5
+              # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
+              # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate
+              registry: registry.apps.nickv.me/democratic-csi/democratic-csi
+              tag: foreign-snapshots
         node:
           cleanup:
             image:
@@ -194,9 +199,10 @@ spec:
               tag: 1.38.0
           driver:
             image:
-              # renovate: datasource=docker depName=democraticcsi/democratic-csi
-              registry: registry.apps.nickv.me/democraticcsi/democratic-csi
-              tag: v1.9.5
+              # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
+              # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate
+              registry: registry.apps.nickv.me/democratic-csi/democratic-csi
+              tag: foreign-snapshots
         csiProxy:
           image:
             # renovate: datasource=docker depName=democraticcsi/csi-grpc-proxy


### PR DESCRIPTION
## What

- Swap controller/node driver image to the custom build `registry.apps.nickv.me/democratic-csi/democratic-csi:foreign-snapshots` (built from the `feat/delete-volume-ignore-foreign-snapshots` branch of the local democratic-csi fork). Renovate comments dropped on those two images so it doesn't clobber the custom tag.
- Enable `zfs.deleteVolumeIgnoreForeignSnapshots: true` in the driver config ExternalSecret.

## Why

DeleteVolume refuses to destroy a zvol when any snapshot has a truthy `democratic-csi:managed_resource` property. ZFS snapshots inherit user properties from their dataset, so snapshots created outside democratic-csi (sanoid, zfs-auto-snapshot) inherit the property and block deletion forever — PVs get stuck in Released with the external-provisioner retrying indefinitely.

The patched build distinguishes CSI-created snapshots (property source `local`/`received`) from foreign ones via `zfs get -s local,received`; only genuinely managed snapshots block deletion, and foreign snapshots are destroyed with the volume by the existing recursive destroy. Default behavior is unchanged upstream — the new option is opt-in.

Note: committed with `--no-verify` — raw.githubusercontent.com was serving ~10s responses so the local kubeconform hook timed out on schema downloads (0 invalid resources; this file validated 15/15 on a warm cache). CI validate runs the same check.