### PR TITLE
ci: validate against local git mirrors of the kubeconform schema repos

### DIFF
--- a/.ci/sync-schemas.sh
+++ b/.ci/sync-schemas.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -euo pipefail
+
+# Maintains local mirrors of the schema repos kubeconform validates against
+# so validate.sh / validate-helm.sh run offline. Two reasons this beats the
+# per-URL downloads (even with -cache):
+#   1. kubeconform never caches misses, and every CR kind (Application,
+#      ExternalSecret, ...) 404s the default schema location before falling
+#      through to the CRDs-catalog — hundreds of round-trips per run.
+#   2. The downloads hit raw.githubusercontent.com (Fastly CDN), which is a
+#      flaky, unauthenticated path. The git smart protocol on github.com is
+#      a separate, reliable endpoint and picks up your gh/ssh credentials.
+#
+# Usage: SCHEMA_MIRROR=.tmp/schemas [KUBE_VERSION=1.35.6] sh .ci/sync-schemas.sh
+# Idempotent; no-ops in a few ms once synced. kubernetes-json-schema is a
+# blob-less sparse clone holding only the requested version's strict schemas;
+# a cluster upgrade just sparse-checkout-adds the new directory.
+
+MIRROR=${SCHEMA_MIRROR:-.tmp/schemas}
+KJS="$MIRROR/kubernetes-json-schema"
+CRDS="$MIRROR/CRDs-catalog"
+
+if [ -z "${KUBE_VERSION:-}" ]; then
+  KUBE_VERSION=$(kubectl version -o json 2>/dev/null | yq '.serverVersion.gitVersion // ""' || true)
+  KUBE_VERSION=${KUBE_VERSION#v}
+fi
+[ -n "$KUBE_VERSION" ] || { echo "sync-schemas: no KUBE_VERSION and no cluster reachable; skipping" >&2; exit 0; }
+VDIR="v${KUBE_VERSION}-standalone-strict"
+
+mkdir -p "$MIRROR"
+
+if [ ! -d "$KJS/.git" ]; then
+  git clone --quiet --depth 1 --filter=blob:none --no-checkout \
+    https://github.com/yannh/kubernetes-json-schema "$KJS"
+  git -C "$KJS" sparse-checkout set --no-cone "/$VDIR/*"
+  git -C "$KJS" checkout --quiet master
+elif [ ! -d "$KJS/$VDIR" ]; then
+  git -C "$KJS" sparse-checkout add --no-cone "/$VDIR/*"
+fi
+if [ ! -d "$KJS/$VDIR" ]; then
+  # version directory landed upstream after our pinned commit
+  git -C "$KJS" fetch --quiet --depth 1 origin master
+  git -C "$KJS" reset --quiet --hard origin/master
+fi
+[ -d "$KJS/$VDIR" ] \
+  || echo "WARNING: kubernetes-json-schema has no $VDIR; kubeconform will fall back to remote" >&2
+
+if [ ! -d "$CRDS/.git" ]; then
+  git clone --quiet --depth 1 https://github.com/datreeio/CRDs-catalog "$CRDS"
+elif [ ! -f "$CRDS/.git/FETCH_HEAD" ] || [ -n "$(find "$CRDS/.git/FETCH_HEAD" -mtime +7)" ]; then
+  # refresh weekly so new CRD versions (renovate chart bumps) keep validating;
+  # best-effort — a stale mirror still beats the flaky raw CDN
+  if git -C "$CRDS" fetch --quiet --depth 1 origin main; then
+    git -C "$CRDS" reset --quiet --hard origin/main
+  else
+    echo "WARNING: CRDs-catalog refresh failed; using stale mirror" >&2
+  fi
+fi
+
+echo "schema mirrors ready in $MIRROR ($VDIR)"

--- a/.ci/validate-helm.sh
+++ b/.ci/validate-helm.sh
@@ -32,6 +32,24 @@ if [ -z "$API_VERSIONS" ]; then
   API_VERSIONS="--api-versions autoscaling.k8s.io/v1 --api-versions monitoring.coreos.com/v1"
 fi
 
+# Prefer local schema mirrors when usable, exclusively — same rationale as
+# validate.sh (offline, deterministic; the mirrors are complete copies).
+SCHEMA_LOCATIONS="
+  -schema-location default
+  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+if [ -n "${SCHEMA_MIRROR:-}" ]; then
+  KUBE_VERSION="$KUBE_VERSION" sh "$(dirname "$0")/sync-schemas.sh" \
+    || echo "WARNING: schema mirror sync failed; continuing with what's on disk" >&2
+  if [ -d "$SCHEMA_MIRROR/kubernetes-json-schema/v${KUBE_VERSION}-standalone-strict" ] \
+    && [ -d "$SCHEMA_MIRROR/CRDs-catalog/.git" ]; then
+    SCHEMA_LOCATIONS="
+  -schema-location $SCHEMA_MIRROR/kubernetes-json-schema/{{.NormalizedKubernetesVersion}}-standalone{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}.json
+  -schema-location $SCHEMA_MIRROR/CRDs-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  else
+    echo "WARNING: schema mirror unusable; validating against remote locations" >&2
+  fi
+fi
+
 # -ignore-missing-schemas: charts ship CRs of their own CRDs (rendered in the
 # same release) that the CRDs-catalog may not carry; missing-schema kinds are
 # reported in the summary as skipped, not failed.
@@ -40,8 +58,7 @@ KUBECONFORM="kubeconform
   -ignore-missing-schemas
   -skip CustomResourceDefinition
   -kubernetes-version $KUBE_VERSION
-  -schema-location default
-  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  $SCHEMA_LOCATIONS"
 if [ -n "${KUBECONFORM_CACHE:-}" ]; then
   mkdir -p "$KUBECONFORM_CACHE"
   KUBECONFORM="$KUBECONFORM -cache $KUBECONFORM_CACHE"

--- a/.ci/validate.sh
+++ b/.ci/validate.sh
@@ -10,12 +10,6 @@ set -euo pipefail
 # for the CRD kind itself (kubernetes-json-schema gap); CRD contents are
 # upstream-generated anyway. The CRDs-catalog location validates our CRs
 # (Application, ExternalSecret, HTTPProxy, Cluster, VPA, ...).
-KUBECONFORM="kubeconform
-  -strict -summary
-  -skip CustomResourceDefinition
-  -schema-location default
-  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
-
 # Match validation to the live cluster version (cukk auto-upgrades the
 # cluster, so never hardcode it). Works in CI step pods via the default SA
 # (GET /version is allowed by system:public-info-viewer) and locally via
@@ -24,6 +18,36 @@ if [ -z "${KUBE_VERSION:-}" ]; then
   KUBE_VERSION=$(kubectl version -o json 2>/dev/null | yq '.serverVersion.gitVersion // ""' || true)
   KUBE_VERSION=${KUBE_VERSION#v}
 fi
+export KUBE_VERSION
+
+# Prefer local schema mirrors (see sync-schemas.sh): kubeconform re-requests
+# every miss on every run (CR kinds 404 the default location regardless of
+# -cache) and raw.githubusercontent.com is flaky. The mirrors are complete
+# copies of both upstream repos, so when they're usable we validate against
+# them exclusively — offline and deterministic; a kind absent upstream is a
+# miss either way. Anything else falls back to the remote locations.
+SCHEMA_LOCATIONS="
+  -schema-location default
+  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+if [ -n "${SCHEMA_MIRROR:-}" ]; then
+  sh "$(dirname "$0")/sync-schemas.sh" \
+    || echo "WARNING: schema mirror sync failed; continuing with what's on disk" >&2
+  if [ -n "$KUBE_VERSION" ] \
+    && [ -d "$SCHEMA_MIRROR/kubernetes-json-schema/v${KUBE_VERSION}-standalone-strict" ] \
+    && [ -d "$SCHEMA_MIRROR/CRDs-catalog/.git" ]; then
+    SCHEMA_LOCATIONS="
+  -schema-location $SCHEMA_MIRROR/kubernetes-json-schema/{{.NormalizedKubernetesVersion}}-standalone{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}.json
+  -schema-location $SCHEMA_MIRROR/CRDs-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  else
+    echo "WARNING: schema mirror unusable; validating against remote locations" >&2
+  fi
+fi
+
+KUBECONFORM="kubeconform
+  -strict -summary
+  -skip CustomResourceDefinition
+  $SCHEMA_LOCATIONS"
+
 if [ -n "$KUBE_VERSION" ]; then
   echo "validating against Kubernetes $KUBE_VERSION"
   KUBECONFORM="$KUBECONFORM -kubernetes-version $KUBE_VERSION"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: kubeconform-validate
         name: kubeconform (same as CI validate step)
-        entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache sh .ci/validate.sh
+        entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache SCHEMA_MIRROR=.tmp/schemas sh .ci/validate.sh
         language: system
         types_or: [yaml]
         pass_filenames: false
@@ -20,7 +20,7 @@ repos:
         pass_filenames: false
       - id: helm-validate
         name: helm render + kubeconform (same as CI validate-helm step)
-        entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache sh .ci/validate-helm.sh
+        entry: env KUBECONFORM_CACHE=.tmp/kubeconform-cache SCHEMA_MIRROR=.tmp/schemas sh .ci/validate-helm.sh
         language: system
         # Chart downloads are slow; only fire when a Helm app (or the script)
         # actually changed — mirrors the CI step's path gate. Needs helm + yq.

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -34,6 +34,9 @@ steps:
     environment:
       # renovate: datasource=github-releases depName=yannh/kubeconform
       KUBECONFORM_VERSION: v0.8.0
+      # git-mirror the schema repos instead of per-URL downloads from the
+      # flaky raw.githubusercontent.com CDN (see .ci/sync-schemas.sh)
+      SCHEMA_MIRROR: .tmp/schemas
     commands:
       - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
       - sh .ci/validate.sh
@@ -61,6 +64,8 @@ steps:
       KUBECONFORM_VERSION: v0.8.0
       # renovate: datasource=github-releases depName=FairwindsOps/pluto
       PLUTO_VERSION: v5.24.0
+      # see validate step
+      SCHEMA_MIRROR: .tmp/schemas
     commands:
       - wget -qO- "https://github.com/yannh/kubeconform/releases/download/$KUBECONFORM_VERSION/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
       - wget -qO- "https://github.com/FairwindsOps/pluto/releases/download/$PLUTO_VERSION/pluto_$${PLUTO_VERSION#v}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin pluto


### PR DESCRIPTION
## Problem

Local kubeconform validation broke completely today when raw.githubusercontent.com degraded (~10s/request, timeouts), and CI failed the same way (pipeline 452, on the democratic-csi PR). Root causes:

1. **kubeconform never caches misses** — every CR kind (Application, ExternalSecret, HTTPProxy, …) 404s the `default` schema location on every run before falling through to the CRDs-catalog. Hundreds of network round-trips per run even with a warm `-cache`.
2. **Cluster upgrades invalidate the cache** — cukk bumped the cluster to 1.35.6, all version-pinned URLs changed, and nothing had been cached since Jul 5.
3. All of it rides the raw.githubusercontent.com Fastly CDN, unauthenticated.

## Fix

`.ci/sync-schemas.sh` maintains local mirrors in `.tmp/schemas` using the **git smart protocol on github.com** (separate endpoint from the raw CDN; locally it picks up your git/gh credentials):

- blob-less sparse clone of `yannh/kubernetes-json-schema`, holding only the live cluster version's `-standalone-strict` dir (cluster upgrade = one `sparse-checkout add`)
- shallow clone of `datreeio/CRDs-catalog`, refreshed weekly, best-effort

When the mirrors are usable the validate scripts use them **exclusively** (they're complete copies, so a miss means the schema doesn't exist upstream either — reported as skipped/not-found instead of a network error). Otherwise they fall back to the remote locations unchanged. `SCHEMA_MIRROR` is set by the pre-commit hooks and now also by the CI validate steps (~7s cold sync per run).

## Numbers

- before: validate.sh ≥26s with healthy network, hard failure today (local and CI)
- cold sync + full validate.sh: ~14s
- warm validate.sh: **~1.4s, fully offline** (verified in a no-network sandbox)
- all 20 Helm apps render + validate clean; all pre-commit hooks pass