### PR TITLE
ci: fix sparse-checkout add crash in schema mirror sync

### DIFF
--- a/.ci/sync-schemas.sh
+++ b/.ci/sync-schemas.sh
@@ -35,7 +35,9 @@ if [ ! -d "$KJS/.git" ]; then
   git -C "$KJS" sparse-checkout set --no-cone "/$VDIR/*"
   git -C "$KJS" checkout --quiet master
 elif [ ! -d "$KJS/$VDIR" ]; then
-  git -C "$KJS" sparse-checkout add --no-cone "/$VDIR/*"
+  # 'add' accepts no mode flag ('set'/'init' only) and inherits the
+  # non-cone mode already persisted by 'set --no-cone' at clone time
+  git -C "$KJS" sparse-checkout add "/$VDIR/*"
 fi
 if [ ! -d "$KJS/$VDIR" ]; then
   # version directory landed upstream after our pinned commit


### PR DESCRIPTION
The schema-mirror helper from #228 crashes with `error: unknown option 'no-cone'` whenever the mirror clone exists but the requested version directory doesn't: `git sparse-checkout add` accepts no mode flag — `--no-cone` belongs to `set`/`init` only, and `add` inherits the non-cone mode already persisted by `set --no-cone` at clone time.

Under `set -e` that killed the sync, so kubeconform fell back to per-URL downloads from raw.githubusercontent.com — the flaky path the mirror exists to avoid — which then got rate-limited and failed the hook on 16 schema *downloads* (0 actually invalid resources). This is what forced the `SKIP=kubeconform-validate` commit in #230.

Fix: drop the flag.

**Tested** (git 2.54.0):
- fresh-clone path → mirror ready, v1.35.6-standalone-strict present
- the crash path (existing mirror, second version dir via `add`) → works
- `pre-commit run kubeconform-validate --all-files` against the mirror → Passed