### PR TITLE
feat: extend Thanos 1h-resolution retention to 5 years

### DIFF
--- a/thanos/thanos-compact-statefulSet.yaml
+++ b/thanos/thanos-compact-statefulSet.yaml
@@ -56,7 +56,7 @@ spec:
         - --debug.accept-malformed-index
         - --retention.resolution-raw=14d
         - --retention.resolution-5m=14d
-        - --retention.resolution-1h=395d
+        - --retention.resolution-1h=1825d
         - --delete-delay=1h
         - --block-files-concurrency=2
         - --compact.concurrency=1


### PR DESCRIPTION
`--retention.resolution-1h`: 395d → 1825d.

Cost estimate from measured block sizes: the 1h tier runs ~2.5 GiB per 14-day block ≈ **65 GiB/year** at pre-cardinality-cut rates, and future blocks will be ~⅓ smaller after the remote-write drops — so 5 years lands around **250–300 GiB total** in the MinIO bucket, reached gradually as history accrues (currently only ~1 month exists).

No other tier changes: raw and 5m stay at 14d. No compact resource impact — retention enforcement is just deletions. Note the 1h tier stores count/sum/min/max/counter aggregates, so `rate()`/min/max/avg remain correct across the full 5-year window.