### PR TITLE
chore(woodpecker): retire forked agent image, track chart default

### DIFF
--- a/woodpecker/application.woodpecker.yaml
+++ b/woodpecker/application.woodpecker.yaml
@@ -96,11 +96,11 @@ spec:
               labels:
                 release: prom
         agent:
-          image:
-            registry: registry.apps.nickv.me
-            repository: woodpeckerci/woodpecker-agent
-            # https://github.com/woodpecker-ci/woodpecker/pull/6710
-            tag: v3.15.0-aa87bcb21
+          # Agent image intentionally left at the chart default (docker.io/
+          # woodpeckerci/woodpecker-agent at appVersion).  k8s userns support
+          # landed upstream in v3.16.0 (woodpecker-ci/woodpecker#6710), so the
+          # previous forked registry.apps.nickv.me build is retired and Renovate
+          # keeps server + agent in sync via the chart bump.
           replicaCount: 1
           env:
             WOODPECKER_SERVER: woodpecker-server:9000


### PR DESCRIPTION
## Why

The Woodpecker **agent** was pinned to a forked image (`registry.apps.nickv.me/woodpecker-agent:v3.15.0-aa87bcb21`) to get k8s **userns support** before it was upstreamed. That work — [woodpecker-ci/woodpecker#6710](https://github.com/woodpecker-ci/woodpecker/pull/6710) ("Add k8s userns support") — is now **merged and shipped in v3.16.0** (merged 2026-06-15, release 2026-06-27; listed in the [v3.16.0 release notes](https://github.com/woodpecker-ci/woodpecker/releases/tag/v3.16.0)).

So the fork is obsolete.

## Change

Drop the `agent.image` override so the agent uses the **chart default** (`docker.io/woodpeckerci/woodpecker-agent` at appVersion `3.16.0`) — the same pattern the **server** already uses (live today as `woodpecker-server:v3.16.0`).

## Renovate impact

- **Before:** the agent sat on a non-upstream tag Renovate couldn't resolve → it was never auto-updated; only the chart (`targetRevision`) was tracked.
- **After:** Renovate bumps the chart via the existing `argocd`/`helm-values` managers, and server + agent move together (zero server/agent skew).

## Validation
- [x] PR #6710 confirmed MERGED and present in v3.16.0 release notes
- [x] `application.woodpecker.yaml` still parses as valid YAML
- [x] pre-commit hooks pass (kubeconform + pluto)

> **Do not merge** — leaving for review. (Also: v3.16.0 already includes the new per-step Prometheus duration/failure metrics, [#6738](https://github.com/woodpecker-ci/woodpecker/pull/6738), so those are already flowing from the server.)