### PR TITLE
feat(contour): drop envoy hostPorts, enable surge rollout

### DIFF
--- a/vendored/contour/kustomization.yaml
+++ b/vendored/contour/kustomization.yaml
@@ -9,8 +9,23 @@ patches:
   - path: patch-configmap.yaml
   # Add resource limits to the contour Deployment
   - path: patch-contour-deployment.yaml
-  # Set envoy image (private mirror), resource limits, and metrics hostPort
+  # Set envoy image (private mirror), resource limits, and a surge-based
+  # rolling update (maxSurge with maxUnavailable=0) for zero-downtime rollouts.
   - path: patch-envoy-daemonset.yaml
+  # Drop vestigial envoy listener hostPorts (80/443). They predate the
+  # Calico-BGP LoadBalancer setup: kube-proxy now DNATs the VIP to the pod
+  # containerPort, and hostPorts block DaemonSet maxSurge (two pods can't
+  # bind the same node port during overlap). Metrics (:8002) are scraped via
+  # the containerPort, so that hostPort (formerly added above) is gone too.
+  - target:
+      kind: DaemonSet
+      name: envoy
+      namespace: projectcontour
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/1/ports/0/hostPort
+      - op: remove
+        path: /spec/template/spec/containers/1/ports/1/hostPort
   # Change the upstream envoy Service from LoadBalancer to ClusterIP
   # (external traffic uses the separate envoy-lb Service instead)
   - target:

--- a/vendored/contour/patch-envoy-daemonset.yaml
+++ b/vendored/contour/patch-envoy-daemonset.yaml
@@ -4,6 +4,13 @@ metadata:
   name: envoy
   namespace: projectcontour
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Surge new pods before terminating old ones (zero-downtime). Requires
+      # the envoy listener hostPorts to be removed — see kustomization.yaml.
+      maxUnavailable: 0
+      maxSurge: 2
   template:
     spec:
       containers:
@@ -24,11 +31,6 @@ spec:
           limits:
             cpu: 1000m
             memory: 512Mi
-        ports:
-        - containerPort: 8002
-          hostPort: 8002
-          name: metrics
-          protocol: TCP
       initContainers:
       - name: envoy-initconfig
         resources:


### PR DESCRIPTION
Remove vestigial envoy listener hostPorts (80/443/8002) and switch the envoy DaemonSet to a surge-based rolling update (maxSurge: 2, maxUnavailable: 0).

These hostPorts predate the Calico-BGP LoadBalancer: kube-proxy already DNATs the VIP to the pod containerPort (externalTrafficPolicy: Local), so the node-port binds were unused. They also blocked DaemonSet maxSurge, since two pods can't bind the same node port during overlap.

With them gone, new envoy pods now come up before old ones are terminated, closing the per-node gap where Calico's BGP route still pointed at a node with no serving envoy. maxSurge: 2 rolls two of the five worker nodes at a time.

Metrics on :8002 stay exposed via containerPort; no ServiceMonitor was scraping the hostPort.