### PR TITLE
feat: serve sonarr over TLS

### DIFF
--- a/sonarr.yaml
+++ b/sonarr.yaml
@@ -118,6 +118,9 @@ spec:
   - name: http
     port: 80
     targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
   - name: metrics
     port: 9707
     targetPort: metrics
@@ -133,6 +136,10 @@ metadata:
   labels:
     app.kubernetes.io/component: sonarr
     app.kubernetes.io/name: arr
+  annotations:
+    # Sonarr loads its SSL cert at startup and does not hot-reload it, so have
+    # Reloader roll the pod when cert-manager rotates the TLS secret.
+    secret.reloader.stakater.com/reload: sonarr-k8s-somemissing-info-tls
 spec:
   replicas: 1
   strategy:
@@ -157,9 +164,23 @@ spec:
           value: "1002"
         - name: PGID
           value: "1001"
+        - name: SONARR__SERVER__ENABLESSL
+          value: "True"
+        - name: SONARR__SERVER__SSLPORT
+          value: "9898"
+        - name: SONARR__SERVER__SSLCERTPATH
+          value: /cert/keystore.p12
+        - name: SONARR__SERVER__SSLCERTPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sonarr-ssl-cert-password
+              key: password
         ports:
         - containerPort: 8989
           name: http
+          protocol: TCP
+        - containerPort: 9898
+          name: https
           protocol: TCP
         startupProbe:
           tcpSocket:
@@ -182,6 +203,9 @@ spec:
           mountPath: /config
         - name: media
           mountPath: /media
+        - name: tls
+          mountPath: /cert
+          readOnly: true
         resources:
           requests:
             memory: 256Mi
@@ -220,4 +244,46 @@ spec:
       - name: media
         persistentVolumeClaim:
           claimName: sonarr-media
+      - name: tls
+        secret:
+          secretName: sonarr-k8s-somemissing-info-tls
 ---
+# mittwald kubernetes-secret-generator auto-fills data.password with a random
+# value; Sonarr reads it as the PFX password. With ServerSideApply the
+# controller owns the `data` field, so ArgoCD self-heal won't clobber it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sonarr-ssl-cert-password
+  namespace: media
+  annotations:
+    secret-generator.v1.mittwald.de/autogenerate: password
+    secret-generator.v1.mittwald.de/secret-type: password
+    secret-generator.v1.mittwald.de/password-length: "32"
+type: Opaque
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sonarr-k8s-somemissing-info-cert
+  namespace: media
+spec:
+  secretName: sonarr-k8s-somemissing-info-tls
+  issuerRef:
+    name: cert-manager-webhook-dnsimple-production
+    kind: ClusterIssuer
+  commonName: &cn sonarr.k8s.somemissing.info
+  dnsNames:
+    - *cn
+  # cert-manager writes keystore.p12 into the Secret alongside tls.crt/tls.key;
+  # Sonarr's single SSL cert path wants a PFX containing the private key, which
+  # cert-manager produces natively (no init container/openssl). LegacyDES for
+  # maximal reader compatibility — cipher strength is moot, tls.key is in the
+  # same Secret. The password is shared with Sonarr via passwordSecretRef.
+  keystores:
+    pkcs12:
+      create: true
+      profile: LegacyDES
+      passwordSecretRef:
+        name: sonarr-ssl-cert-password
+        key: password


### PR DESCRIPTION
## What

Enables Sonarr to serve HTTPS on the internal `sonarr.k8s.somemissing.info` endpoint (LAN-only, via the existing external-dns `k8s.somemissing.info` record — no Contour).

- New `Certificate` `sonarr-k8s-somemissing-info-cert` → secret `sonarr-k8s-somemissing-info-tls`, issued by `cert-manager-webhook-dnsimple-production` (Let's Encrypt, DNS-01) — same pattern as `grafana.yaml` / `searxng.yaml`.
- The Certificate uses cert-manager's native `keystores.pkcs12` (`profile: LegacyDES`), so cert-manager writes `keystore.p12` into the same Secret alongside `tls.crt`/`tls.key`.
- Service gains a `https` port (443 → container `https`/9898). HTTP on 8989 is left intact for the liveness/readiness probes and `exportarr`.

## Why a keystore (PFX), not the PEM directly

Sonarr's SSL config only takes a single cert path + password (PFX-oriented — Kestrel's single-path loader drops a PEM's private key), so unlike grafana it can't read `tls.crt`/`tls.key` separately. cert-manager produces the PFX **natively** via `keystores.pkcs12`, so there's no init container or openssl. The keystore password is a mittwald secret-generator Secret (`sonarr-ssl-cert-password`), shared by cert-manager (`passwordSecretRef`) and Sonarr (`secretKeyRef`). `LegacyDES` for maximal reader compatibility — cipher strength is moot since `tls.key` lives in the same Secret.

## Hot reload (the bit you flagged)

Sonarr loads its SSL cert at startup and does **not** watch the file, so a rotated cert wouldn't take effect on its own. The Deployment carries:

```yaml
annotations:
  secret.reloader.stakater.com/reload: sonarr-k8s-somemissing-info-tls
```

Reloader rolls the pod when cert-manager rotates the TLS secret (~60d); on restart Sonarr reads the freshly written `keystore.p12`.

## Notes / things to eyeball on deploy

- Both HTTP (8989) and HTTPS (9898) stay up. If you'd rather force HTTPS-only, the probes/exportarr would need to move to the SSL port.
- Verify after sync: `openssl s_client -connect sonarr.k8s.somemissing.info:443` shows the LE cert; `kubectl -n media get certificate sonarr-k8s-somemissing-info-cert` shows Ready=True with `keystore.p12` materialized; `kubectl -n media rollout status deploy/sonarr` is healthy.

## Validation

`kubeconform -strict` on `sonarr.yaml` → 9 resources, 0 invalid (pre-commit hook + local run). cert-manager **v1.21** supports `keystores.pkcs12` with `profile` (needs ≥1.13).
