### PR TITLE
fix(ci): stop PR-only deploy-key secret from erroring push pipelines

### DIFF
--- a/.ci/vendir-push.sh
+++ b/.ci/vendir-push.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -euo pipefail
+
+# Pushes the vendir-sync commit back to the PR branch over SSH.
+#
+# Split out of vendir-sync.sh so the deploy-key secret is referenced only from
+# a step gated to `when: event=pull_request`. vendir-sync must stay unfiltered
+# (mirror-images depends_on it, and Woodpecker rejects a DAG edge to a
+# condition-filtered step), so it cannot carry the PR-only secret without
+# erroring push-to-main pipelines at compile time. This step has no dependents,
+# so filtering it out on push is safe.
+#
+# vendir-sync writes .tmp/vendir-push-needed only when it actually commits;
+# absent that marker there is nothing to push.
+
+if [ ! -f .tmp/vendir-push-needed ]; then
+  echo "No vendir-sync commit to push; nothing to do."
+  exit 0
+fi
+
+# The clone remote is credential-less HTTPS (Woodpecker injects netrc only into
+# trusted clone plugins, never into commands steps), so push with the deploy
+# key from VENDIR_PUSH_SSH_KEY.
+command -v ssh >/dev/null || apk add --no-cache openssh-client
+KEY_FILE=$(mktemp)
+printf '%s\n' "$VENDIR_PUSH_SSH_KEY" > "$KEY_FILE"
+KNOWN_HOSTS=$(mktemp)
+# github.com's published ed25519 host key (docs.github.com: GitHub's SSH key fingerprints)
+echo 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' > "$KNOWN_HOSTS"
+export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o UserKnownHostsFile=$KNOWN_HOSTS -o IdentitiesOnly=yes"
+git push "git@github.com:${CI_REPO}.git" "HEAD:${CI_COMMIT_SOURCE_BRANCH}"
+rm -f "$KEY_FILE"
+echo "Pushed vendir sync results to ${CI_COMMIT_SOURCE_BRANCH}."

--- a/.ci/vendir-sync.sh
+++ b/.ci/vendir-sync.sh
@@ -2,8 +2,13 @@
 set -euo pipefail
 
 # Runs `vendir sync` on PR branches and commits the updated vendored/*/base
-# files back to the branch. The Woodpecker step's `path:` filter ensures this
-# only runs when vendir.yml or vendir.lock.yml actually changed.
+# files locally. The commit lands in the shared workspace so the mirror-images
+# step (which depends_on this step) sees the synced files in its BASE...HEAD
+# diff. The commit is *not* pushed here: pushing needs the deploy key, which is
+# a pull_request-scoped secret, and referencing it from a step that also runs
+# on push events errors the whole pipeline at compile time. The push therefore
+# lives in the separate vendir-push step (when: pull_request), which this step
+# signals via the .tmp/vendir-push-needed marker below.
 
 # Gating formerly done by the Woodpecker `when:` filter (the step must always
 # exist because mirror-images depends_on it — Woodpecker rejects DAG edges to
@@ -34,16 +39,8 @@ git commit -m "chore: vendir sync
 
 Co-authored-by: Woodpecker CI <woodpecker@ci>"
 
-# Push back to the PR branch over SSH. The clone remote is credential-less
-# HTTPS (Woodpecker injects netrc only into trusted clone plugins, never into
-# commands steps), so push with the deploy key from VENDIR_PUSH_SSH_KEY.
-command -v ssh >/dev/null || apk add --no-cache openssh-client
-KEY_FILE=$(mktemp)
-printf '%s\n' "$VENDIR_PUSH_SSH_KEY" > "$KEY_FILE"
-KNOWN_HOSTS=$(mktemp)
-# github.com's published ed25519 host key (docs.github.com: GitHub's SSH key fingerprints)
-echo 'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' > "$KNOWN_HOSTS"
-export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o UserKnownHostsFile=$KNOWN_HOSTS -o IdentitiesOnly=yes"
-git push "git@github.com:${CI_REPO}.git" "HEAD:${CI_COMMIT_SOURCE_BRANCH}"
-rm -f "$KEY_FILE"
-echo "Pushed vendir sync results to ${CI_COMMIT_SOURCE_BRANCH}."
+# Signal the vendir-push step that there's a commit to push back to the PR
+# branch. .tmp is gitignored, so this marker never ends up in the commit.
+mkdir -p .tmp
+: > .tmp/vendir-push-needed
+echo "Committed vendir sync results; flagged for push."

--- a/.woodpecker.yaml
+++ b/.woodpecker.yaml
@@ -9,7 +9,9 @@
 # Step DAG (depends_on): validate, validate-pluto, and validate-helm run in
 # parallel from the start; vendir-sync waits for the steps that read
 # vendored/ (it rewrites those files in the shared workspace); mirror-images
-# waits for vendir-sync (it git-diffs the same workspace).
+# and vendir-push both wait for vendir-sync (mirror-images git-diffs the same
+# workspace; vendir-push, PR-only, pushes vendir-sync's commit back to the PR
+# branch with the deploy key).
 clone:
   git:
     # renovate: datasource=docker depName=woodpeckerci/plugin-git
@@ -77,18 +79,34 @@ steps:
     # No `when:` filter: mirror-images depends_on this step, and Woodpecker
     # rejects a DAG whose dependency is filtered out by conditions. The
     # equivalent gating (PR event + vendir file changes) lives in the script.
+    # This step no longer references the deploy-key secret: an event-scoped
+    # (pull_request) secret referenced from an always-on step errors the whole
+    # pipeline on push events at compile time. The push moved to vendir-push.
     depends_on: [validate, validate-pluto]
     environment:
       # renovate: datasource=github-releases depName=carvel-dev/vendir
       VENDIR_VERSION: v0.46.0
+    commands:
+      - wget -qO /usr/local/bin/vendir "https://github.com/carvel-dev/vendir/releases/download/$VENDIR_VERSION/vendir-linux-amd64"
+      - chmod +x /usr/local/bin/vendir
+      - sh .ci/vendir-sync.sh
+
+  vendir-push:
+    # renovate: datasource=docker depName=alpine/k8s
+    image: alpine/k8s:1.36.2
+    # Gated to pull_request so the PR-only deploy-key secret is never evaluated
+    # on push events. Nothing depends_on this step, so filtering it out on push
+    # keeps the DAG valid. vendir-sync signals it via .tmp/vendir-push-needed.
+    when:
+      - event: pull_request
+    depends_on: [vendir-sync]
+    environment:
       # Write-access GitHub deploy key for pushing sync results back to the
       # PR branch. Woodpecker repo secret scoped to this image + pull_request.
       VENDIR_PUSH_SSH_KEY:
         from_secret: vendir_push_ssh_key
     commands:
-      - wget -qO /usr/local/bin/vendir "https://github.com/carvel-dev/vendir/releases/download/$VENDIR_VERSION/vendir-linux-amd64"
-      - chmod +x /usr/local/bin/vendir
-      - sh .ci/vendir-sync.sh
+      - sh .ci/vendir-push.sh
 
   mirror-images:
     # renovate: datasource=docker depName=ghcr.io/regclient/regctl


### PR DESCRIPTION
## Problem

Every push-to-`main` Woodpecker pipeline has been erroring at compile time:

```
secret "vendir_push_ssh_key" is not allowed to be used with pipeline event "push"
```

100% of recent push pipelines failed this way (535, 536, 538, 541, 543, 548, 553, 554, 556, 561, 562, 564, 567), while all `pull_request` pipelines succeeded.

**Root cause:** `.woodpecker.yaml` runs on both `pull_request` and `push: main`. The `vendir-sync` step referenced the `vendir_push_ssh_key` secret but has no `when:` filter — it must always exist because `mirror-images` `depends_on` it, and Woodpecker rejects a DAG edge to a condition-filtered step. Woodpecker validates secret event-scoping at *compile time*, so on push events it saw an always-on step referencing a `pull_request`-only secret and errored the whole pipeline before any step ran. The script's own event guard never got the chance to run.

**Impact:** the push-to-main run is the self-healing backstop that re-mirrors missing images (`mirror-images.sh` has a dedicated `push` code path). That backstop has **never once run successfully**.

## Fix

Split the SSH push into a new `vendir-push` step:

- `vendir-sync` keeps `vendir sync` + the local git **commit** (no secret), so `mirror-images` still sees the synced files in its `BASE...HEAD` diff. On commit it drops a gitignored `.tmp/vendir-push-needed` marker.
- `vendir-push` (new) does only the SSH push, gated `when: event=pull_request`, guarded by the marker. Nothing `depends_on` it, so it's filtered out cleanly on push and its secret is never evaluated.

Push pipelines now run `validate` → `vendir-sync` → `mirror-images` green. Preserves the least-privilege scoping of the deploy key — no Woodpecker server change needed.

## Validation

- `.woodpecker.yaml` parses as valid YAML; both scripts pass `sh -n`
- pre-commit kubeconform + pluto checks passed
- marker path confirmed gitignored; `mirror-images.sh` doesn't touch `.tmp`

## Note (out of scope)

PR #265 merged with its check stuck on `PENDING` (pipeline 563 was canceled) — branch protection isn't requiring the Woodpecker check to be green before merge. Separate GitHub setting if you want checks to block merges.