### PR TITLE
fix(woodpecker): pin workflow step pods to one node + soft repo spread

### DIFF
--- a/woodpecker/application.woodpecker.yaml
+++ b/woodpecker/application.woodpecker.yaml
@@ -106,8 +106,38 @@ spec:
             WOODPECKER_SERVER: woodpecker-server:9000
             WOODPECKER_BACKEND: kubernetes
             WOODPECKER_BACKEND_K8S_NAMESPACE: woodpecker
+            # Workspace PVCs come from the only StorageClass we have,
+            # zfs-generic-iscsi-csi (democratic-csi iSCSI), which is
+            # ReadWriteOnce.  RWX=false makes Woodpecker request RWO PVCs to
+            # match.  All step pods of a workflow share that single workspace
+            # PVC, so with RWO they MUST land on one node -- otherwise the
+            # second/third parallel step pod hits a "Multi-Attach error" and
+            # hangs in ContainerCreating until the holder detaches, which
+            # stalls the pipeline long enough for the server to drop the task
+            # lease ("queue: task not found") and fail the workflow.
             WOODPECKER_BACKEND_K8S_STORAGE_RWX: "false"
             WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
+            # Pin every pod belonging to the same workflow onto one node so the
+            # shared RWO workspace volume only ever attaches to a single node.
+            # matchLabelKeys keys off woodpecker's per-workflow task-uuid label;
+            # the first pod schedules freely and the rest co-locate with it.
+            # (requires k8s >= 1.31 for MatchLabelKeysInPodAffinity GA -- this
+            # cluster is 1.35.)  No podAntiAffinity: multiple workflows may
+            # still share a node, we only need same-workflow co-location.
+            #
+            # FUTURE: the cleaner fix is RWX workspaces -- stand up an NFS
+            # StorageClass (democratic-csi supports it) and set
+            # WOODPECKER_BACKEND_K8S_STORAGE_RWX=true +
+            # WOODPECKER_BACKEND_K8S_STORAGE_CLASS=<nfs-class>.  That removes
+            # this scheduling constraint entirely and drops the per-step iSCSI
+            # provision/attach/detach latency that also slows pipelines.
+            WOODPECKER_BACKEND_K8S_POD_AFFINITY: |
+              podAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector: {}
+                    matchLabelKeys:
+                      - woodpecker-ci.org/task-uuid
+                    topologyKey: kubernetes.io/hostname
             WOODPECKER_CONNECT_RETRY_COUNT: "5"
           persistence:
             enabled: true

--- a/woodpecker/application.woodpecker.yaml
+++ b/woodpecker/application.woodpecker.yaml
@@ -117,20 +117,28 @@ spec:
             # lease ("queue: task not found") and fail the workflow.
             WOODPECKER_BACKEND_K8S_STORAGE_RWX: "false"
             WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
-            # Pin every pod belonging to the same workflow onto one node so the
-            # shared RWO workspace volume only ever attaches to a single node.
-            # matchLabelKeys keys off woodpecker's per-workflow task-uuid label;
-            # the first pod schedules freely and the rest co-locate with it.
-            # (requires k8s >= 1.31 for MatchLabelKeysInPodAffinity GA -- this
-            # cluster is 1.35.)  No podAntiAffinity: multiple workflows may
-            # still share a node, we only need same-workflow co-location.
+            # Scheduling rules for worker pods (agent-wide, applies to every
+            # repo's pipelines since they all share this one agent).  Keys off
+            # the woodpecker-ci.org/{task-uuid,repo-id} labels the backend
+            # stamps on each pod.  matchLabelKeys/mismatchLabelKeys require k8s
+            # >= 1.31 (MatchLabelKeysInPodAffinity GA) -- this cluster is 1.35.
+            #
+            #  - HARD podAffinity on task-uuid: all pods of one workflow share a
+            #    single RWO workspace PVC, so they MUST land on one node or the
+            #    later pods hit a Multi-Attach error and hang.  The first pod of
+            #    a workflow schedules freely; the rest co-locate with it.
+            #  - SOFT podAffinity on repo-id: prefer to keep other workflows of
+            #    the SAME repo on the same node to reuse warm caches (poetry
+            #    venv, buildkit layers).
+            #  - SOFT podAntiAffinity on repo-id: prefer to keep DIFFERENT repos
+            #    on different nodes so one repo's build doesn't crowd another's.
             #
             # FUTURE: the cleaner fix is RWX workspaces -- stand up an NFS
             # StorageClass (democratic-csi supports it) and set
             # WOODPECKER_BACKEND_K8S_STORAGE_RWX=true +
             # WOODPECKER_BACKEND_K8S_STORAGE_CLASS=<nfs-class>.  That removes
-            # this scheduling constraint entirely and drops the per-step iSCSI
-            # provision/attach/detach latency that also slows pipelines.
+            # the hard co-location constraint entirely and drops the per-step
+            # iSCSI provision/attach/detach latency that also slows pipelines.
             WOODPECKER_BACKEND_K8S_POD_AFFINITY: |
               podAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:
@@ -138,6 +146,21 @@ spec:
                     matchLabelKeys:
                       - woodpecker-ci.org/task-uuid
                     topologyKey: kubernetes.io/hostname
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector: {}
+                      matchLabelKeys:
+                        - woodpecker-ci.org/repo-id
+                      topologyKey: kubernetes.io/hostname
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector: {}
+                      mismatchLabelKeys:
+                        - woodpecker-ci.org/repo-id
+                      topologyKey: kubernetes.io/hostname
             WOODPECKER_CONNECT_RETRY_COUNT: "5"
           persistence:
             enabled: true


### PR DESCRIPTION
## Problem

Woodpecker pipelines were running slowly and/or failing to launch. Root cause (observed live in-cluster):

- The k8s backend runs **one pod per step**, and all steps in a workflow share **one workspace PVC**.
- Our only StorageClass is `zfs-generic-iscsi-csi` (democratic-csi iSCSI, **RWO**, `volumeBindingMode: Immediate`), so `WOODPECKER_BACKEND_K8S_STORAGE_RWX=false` requests **ReadWriteOnce** workspace PVCs.
- An RWO volume can only attach to **one node**. The scheduler scattered step pods across our 5 worker nodes, so a pod on a second node hit:

  ```
  Warning FailedAttachVolume  Multi-Attach error for volume "pvc-..."
    Volume is already used by pod(s) wp-...
  ```

  and hung in `ContainerCreating` until the holder detached.
- The stall was long enough that the server dropped the task lease, failing the workflow:

  ```
  agent:  "failed to extend workflow lease" -> error "queue: task not found"
  server: "queue.Done: cannot ack workflow" -> error "queue: task not found"
  ```

  Seen on this repo's deploy pipelines (repo_id 3) and `python-envoy-authz`.

## Fix

Add agent-wide `WOODPECKER_BACKEND_K8S_POD_AFFINITY` (supported since v3.13 / woodpecker-ci/woodpecker#5854; we run v3.16). `config.PodAffinity` is a standard `corev1.Affinity`, so all of the following are supported:

**Hard — correctness:** co-locate all pods sharing `woodpecker-ci.org/task-uuid` (same workflow) onto one node, so the shared RWO volume only ever attaches to one node. First pod schedules freely; the rest follow.

**Soft — locality (`weight: 100` podAffinity on `woodpecker-ci.org/repo-id`):** prefer to keep other workflows of the *same repo* on the same node to reuse warm caches (poetry venv, buildkit layers).

**Soft — spread (`weight: 100` podAntiAffinity on `repo-id` `mismatchLabelKeys`):** prefer to keep *different* repos on different nodes so one repo's build doesn't crowd another's.

Uses `matchLabelKeys` / `mismatchLabelKeys` (GA `MatchLabelKeysInPodAffinity`, k8s >= 1.31 — cluster is 1.35).

### Scope

This agent is **shared** by all repos on `woodpecker.k8s.somemissing.info`. `python-envoy-authz` (and every other repo) uses it with no backend config of its own, so this change covers them too — no per-repo `.woodpecker.yaml` change needed, and step-level affinity stays disabled (`..._ALLOW_FROM_STEP` off).

## Follow-up (documented inline, not in this PR)

The cleaner long-term fix is RWX workspaces: stand up an NFS StorageClass (democratic-csi supports it) and set `WOODPECKER_BACKEND_K8S_STORAGE_RWX=true` + `WOODPECKER_BACKEND_K8S_STORAGE_CLASS=<nfs-class>`. That removes the hard co-location constraint entirely and drops the per-step iSCSI provision/attach/detach latency that also slows pipelines.