### PR TITLE
fix(ci): master-standalone-strict fallback for cukk-upgrade schema race

### DIFF
--- a/.ci/sync-schemas.sh
+++ b/.ci/sync-schemas.sh
@@ -26,26 +26,35 @@ if [ -z "${KUBE_VERSION:-}" ]; then
 fi
 [ -n "$KUBE_VERSION" ] || { echo "sync-schemas: no KUBE_VERSION and no cluster reachable; skipping" >&2; exit 0; }
 VDIR="v${KUBE_VERSION}-standalone-strict"
+# Version-agnostic escape hatch (see validate.sh): keeps every built-in kind
+# available even when the cluster's exact patch isn't published upstream yet.
+MDIR="master-standalone-strict"
 
 mkdir -p "$MIRROR"
 
 if [ ! -d "$KJS/.git" ]; then
   git clone --quiet --depth 1 --filter=blob:none --no-checkout \
     https://github.com/yannh/kubernetes-json-schema "$KJS"
-  git -C "$KJS" sparse-checkout set --no-cone "/$VDIR/*"
+  git -C "$KJS" sparse-checkout set --no-cone "/$VDIR/*" "/$MDIR/*"
   git -C "$KJS" checkout --quiet master
 elif [ ! -d "$KJS/$VDIR" ]; then
   # 'add' accepts no mode flag ('set'/'init' only) and inherits the
   # non-cone mode already persisted by 'set --no-cone' at clone time
-  git -C "$KJS" sparse-checkout add "/$VDIR/*"
+  git -C "$KJS" sparse-checkout add "/$VDIR/*" "/$MDIR/*"
 fi
 if [ ! -d "$KJS/$VDIR" ]; then
   # version directory landed upstream after our pinned commit
   git -C "$KJS" fetch --quiet --depth 1 origin master
   git -C "$KJS" reset --quiet --hard origin/master
 fi
+# Ensure the escape-hatch dir is materialized on mirrors cloned before MDIR
+# was added to the sparse-checkout set (the elif above only fires when VDIR is
+# missing, so a warm mirror with VDIR would otherwise never pick up MDIR).
+if [ ! -d "$KJS/$MDIR" ]; then
+  git -C "$KJS" sparse-checkout add "/$MDIR/*"
+fi
 [ -d "$KJS/$VDIR" ] \
-  || echo "WARNING: kubernetes-json-schema has no $VDIR; kubeconform will fall back to remote" >&2
+  || echo "WARNING: kubernetes-json-schema has no $VDIR; kubeconform will fall back to master/remote" >&2
 
 if [ ! -d "$CRDS/.git" ]; then
   git clone --quiet --depth 1 https://github.com/datreeio/CRDs-catalog "$CRDS"

--- a/.ci/validate-helm.sh
+++ b/.ci/validate-helm.sh
@@ -34,9 +34,14 @@ fi
 
 # Prefer local schema mirrors when usable, exclusively — same rationale as
 # validate.sh (offline, deterministic; the mirrors are complete copies).
+# MASTER_STRICT_FALLBACK: version-agnostic escape hatch for the cukk-upgrade
+# race (see validate.sh); without it every built-in kind is skipped during the
+# window before yannh/kubernetes-json-schema publishes the new patch's dir.
+MASTER_STRICT_FALLBACK="-schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json"
 SCHEMA_LOCATIONS="
   -schema-location default
-  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
+  $MASTER_STRICT_FALLBACK"
 if [ -n "${SCHEMA_MIRROR:-}" ]; then
   KUBE_VERSION="$KUBE_VERSION" sh "$(dirname "$0")/sync-schemas.sh" \
     || echo "WARNING: schema mirror sync failed; continuing with what's on disk" >&2
@@ -44,7 +49,9 @@ if [ -n "${SCHEMA_MIRROR:-}" ]; then
     && [ -d "$SCHEMA_MIRROR/CRDs-catalog/.git" ]; then
     SCHEMA_LOCATIONS="
   -schema-location $SCHEMA_MIRROR/kubernetes-json-schema/{{.NormalizedKubernetesVersion}}-standalone{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}.json
-  -schema-location $SCHEMA_MIRROR/CRDs-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  -schema-location $SCHEMA_MIRROR/kubernetes-json-schema/master-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json
+  -schema-location $SCHEMA_MIRROR/CRDs-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
+  $MASTER_STRICT_FALLBACK"
   else
     echo "WARNING: schema mirror unusable; validating against remote locations" >&2
   fi

--- a/.ci/validate.sh
+++ b/.ci/validate.sh
@@ -26,18 +26,33 @@ export KUBE_VERSION
 # copies of both upstream repos, so when they're usable we validate against
 # them exclusively — offline and deterministic; a kind absent upstream is a
 # miss either way. Anything else falls back to the remote locations.
+# A version-agnostic fallback: the master-standalone-strict directory is kept
+# current upstream and carries every built-in kind regardless of released patch.
+# This catches the race where cukk upgrades the cluster to a brand-new patch
+# (e.g. 1.35.7) before yannh/kubernetes-json-schema publishes that patch's
+# schema dir — both the mirror and the version-keyed remote default 404 in
+# lockstep, so without this escape hatch every built-in kind errors as "could
+# not find schema". master tracks the latest Kubernetes, but built-in kinds are
+# structurally stable across patches, so it's a safe match for any recent patch.
+MASTER_STRICT_FALLBACK="-schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json"
+
 SCHEMA_LOCATIONS="
   -schema-location default
-  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
+  $MASTER_STRICT_FALLBACK"
 if [ -n "${SCHEMA_MIRROR:-}" ]; then
   sh "$(dirname "$0")/sync-schemas.sh" \
     || echo "WARNING: schema mirror sync failed; continuing with what's on disk" >&2
   if [ -n "$KUBE_VERSION" ] \
     && [ -d "$SCHEMA_MIRROR/kubernetes-json-schema/v${KUBE_VERSION}-standalone-strict" ] \
     && [ -d "$SCHEMA_MIRROR/CRDs-catalog/.git" ]; then
+    # Mirror first (offline, deterministic); master-standalone-strict (local if
+    # synced, else remote) as the escape hatch for a missing patch schema dir.
     SCHEMA_LOCATIONS="
   -schema-location $SCHEMA_MIRROR/kubernetes-json-schema/{{.NormalizedKubernetesVersion}}-standalone{{.StrictSuffix}}/{{.ResourceKind}}{{.KindSuffix}}.json
-  -schema-location $SCHEMA_MIRROR/CRDs-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  -schema-location $SCHEMA_MIRROR/kubernetes-json-schema/master-standalone-strict/{{.ResourceKind}}{{.KindSuffix}}.json
+  -schema-location $SCHEMA_MIRROR/CRDs-catalog/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
+  $MASTER_STRICT_FALLBACK"
   else
     echo "WARNING: schema mirror unusable; validating against remote locations" >&2
   fi


### PR DESCRIPTION
## Problem

CI `validate` step failed on PR #281 — **exit 123, 166 "could not find schema" errors** — but the manifests were fine.

Root cause is a race between cukk and the upstream schema repo:
- cukk auto-upgraded the cluster to **1.35.7** at ~00:12 UTC on 2026-07-23.
- `yannh/kubernetes-json-schema` published `v1.35.7-standalone-strict` ~12h later (commit "Adding new schemas" at 12:22 UTC).
- In that window, both the local mirror path **and** the version-keyed remote default 404'd in lockstep for every built-in kind (ServiceAccount, Service, ConfigMap, Secret, Namespace, Job, Deployment, …). → 166 errors → `xargs` exit 123.

kubeconform has **no built-in version fallback** — ``{{.NormalizedKubernetesVersion}}`` renders to the literal patch (e.g. `1.35.7`), never `master`. So the script's "fall back to remote" path hit the same gap as the mirror.

## Fix

Add a **version-agnostic escape hatch**: the `master-standalone-strict` directory is kept current upstream and carries every built-in kind regardless of released patch. Built-in kinds are structurally stable across patches, so it's a safe structural match for any recent patch.

- **`.ci/validate.sh` / `.ci/validate-helm.sh`**: append `master-standalone-strict` as a final `-schema-location` in both the remote and mirror branches (local mirror copy first, then remote). For `validate-helm.sh` this also closes a silent coverage gap — with `-ignore-missing-schemas` the race would *skip* every built-in kind instead of failing, i.e. validate nothing useful during the window.
- **`.ci/sync-schemas.sh`**: sparse-checkout `master-standalone-strict` alongside the per-version dir, and materialize it on warm mirrors cloned before this change, so the offline path keeps the escape hatch.

## Verification

Simulated the race with `KUBE_VERSION=1.35.99` (no upstream dir):

| Path | Before | After |
|---|---|---|
| `validate.sh` (remote) | 166 errors, exit 123 | ✅ all valid, exit 0 |
| `validate.sh` (mirror, missing version) | falls to remote → 166 errors | ✅ all valid, exit 0 |
| `validate-helm.sh` | silently skips built-in kinds | ✅ built-in kinds validate |

Normal happy path (real cluster version, with and without mirror) unchanged: **335 valid, 0 errors**. `sync-schemas.sh` confirmed to materialize `master-standalone-strict/serviceaccount-v1.json` locally.

This de-risks every future cukk upgrade that lands before the schema repo catches up — the exact race that broke this PR.