### PR TITLE
fix(ci): mirror-images skips refs with no upstream instead of failing

### DIFF
--- a/.ci/mirror-images.sh
+++ b/.ci/mirror-images.sh
@@ -181,6 +181,16 @@ while IFS= read -r full; do
   echo "==> $src -> $full"
   if regctl image copy "$src" "$full"; then
     mirrored=$((mirrored + 1))
+  elif ! regctl manifest head "$src" >/dev/null 2>&1; then
+    # The upstream ref doesn't exist, so there's nothing to mirror — e.g. a
+    # locally-built image (built+pushed by CI) whose mirror path has no
+    # upstream counterpart. Skip rather than fail. Prefer listing such paths
+    # in renovate.json ignoreDeps too, so this probe isn't retried every run
+    # and Renovate stops tracking them; this guard is the safety net for any
+    # that slip through. A copy failure where the source DOES exist (auth,
+    # network, digest mismatch) still counts as a real failure below.
+    echo "skip $full (upstream $src not found)"
+    skipped=$((skipped + 1))
   else
     echo "FAILED: $src -> $full" >&2
     failed=$((failed + 1))


### PR DESCRIPTION
## Problem

`.ci/mirror-images.sh` runs `regctl image copy <upstream> <mirror>` for every mirror ref on added lines. When a ref has **no upstream** — e.g. a locally-built image pushed straight to `registry.apps.nickv.me` — the copy fails and, via `failed>0` + `set -e`, the whole mirror step fails.

## Fix

If a copy fails, probe the source with `regctl manifest head`:
- **source doesn't exist** → `skip` (counts as skipped, not failed) — nothing to mirror.
- **source exists** but copy failed (auth / network / digest mismatch) → still a **real failure**, as before.

So genuinely-missing upstreams no longer break CI, while real copy errors are still caught. `renovate.json` `ignoreDeps` remains the preferred way to declare locally-built paths (skipped up front); this guard is the safety net for any not listed.

No manifest changes; shell-only. `sh -n` clean.