### PR TITLE
fix(jellyfin): bump volsync restic cacheCapacity to 8Gi

### DIFF
--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -81,6 +81,9 @@ spec:
 # Backs up the whole PVC including JELLYFIN_CACHE_DIR — volsync's restic
 # mover has no path excludes, so transcoding/image cache churn lands in
 # snapshots. Restic dedup keeps this tolerable.
+# cacheCapacity covers restic's repo cache (index + cached packs); the repo
+# holds ~7.5Gi of data plus transcode churn between prunes, which overflowed
+# the prior 4Gi cache with "no space left on device". Sized above the repo.
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
@@ -93,7 +96,7 @@ spec:
   restic:
     pruneIntervalDays: 14
     repository: restic-repo-jellyfin
-    cacheCapacity: 4Gi
+    cacheCapacity: 8Gi
     moverSecurityContext:
       runAsUser: 1009
       runAsGroup: 1001


### PR DESCRIPTION
## Problem

The `jellyfin-data` ReplicationSource restic backups have been failing. Latest mover status:

\`\`\`
Fatal: unable to save snapshot: Copy: write
/cache/<id>/data/.../tmp-...: no space left on device
\`\`\`

## Root cause

The restic cache PVC (`cacheCapacity: 4Gi`) overflowed. The `jellyfin-data` PVC is backed up in full — volsync's restic mover has no path excludes, so transcoding/image-cache churn lands in the repo (~7.5 GiB of data plus churn between prunes). Restic caches index + packs under \`/cache\`, which exceeds 4 Gi and aborts the run partway through the scan.

## Fix

Raise \`cacheCapacity\` from \`4Gi\` to \`8Gi\` (above the current repo size). The cache PVC is thin-provisioned on \`zfs-generic-iscsi-csi\` (\`allowVolumeExpansion=true\`), so only the restic cache actually used is allocated.

## Verification

- [x] `.ci/validate.sh` (kubeconform) + `.ci/validate-pluto.sh` (pluto) pass
- [ ] ArgoCD self-heals the change; volsync resizes the cache PVC to 8Gi
- [ ] Next scheduled (`*/30`) backup completes: `latestMoverStatus.result == Successful`

Applies via the \`vmubtkube-a\` ArgoCD Application (auto-sync, selfHeal, ServerSideApply).