### PR TITLE
fix(argocd): stop sync overwriting in-cluster Secret values

### DIFF
--- a/application.argocd.yaml
+++ b/application.argocd.yaml
@@ -59,6 +59,18 @@ spec:
             resource.customizations.ignoreDifferences.apps_StatefulSet: |
               jqPathExpressions:
               - .spec.volumeClaimTemplates[].metadata.creationTimestamp
+            # Every Secret value committed to this repo is the placeholder
+            # base64 `++++++++`; the real values are filled in-cluster by
+            # secret-generator, CNPG or ESO. Argo owns the Secret shell, never
+            # its contents -- without this, a full sync writes placeholders over
+            # live credentials (Postgres, ClickHouse, Mongo, CSI, Grafana).
+            # `_Secret` is the core (empty) API group; a bare `Secret` key would
+            # silently never match.
+            # Opt a Secret back into git-managed values with:
+            #   k8s.somemissing.info/argocd-manage-secret-data: "true"
+            resource.customizations.ignoreDifferences._Secret: |
+              jqPathExpressions:
+              - 'if (.metadata.annotations."k8s.somemissing.info/argocd-manage-secret-data" // "") == "true" then empty else (.data, .stringData) end'
             resource.trackingmethod: annotation
             resource.customizations.health.postgresql.cnpg.io_Cluster: |
               hs = {}

--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.calico.yaml
+++ b/application.calico.yaml
@@ -20,6 +20,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     - CreateNamespace=true
     retry:
       backoff:

--- a/application.cert-manager-webhook-dnsimple.yaml
+++ b/application.cert-manager-webhook-dnsimple.yaml
@@ -36,6 +36,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.crds.yaml
+++ b/application.crds.yaml
@@ -28,6 +28,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -149,6 +149,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.external-secrets.yaml
+++ b/application.external-secrets.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     - CreateNamespace=true
     retry:
       backoff:

--- a/application.fluentbit.yaml
+++ b/application.fluentbit.yaml
@@ -18,6 +18,7 @@ spec:
       - PruneLast=true
       - ServerSideApply=true
       - ApplyOutOfSyncOnly=true
+      - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.hyperdx.yaml
+++ b/application.hyperdx.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.immich.yaml
+++ b/application.immich.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.intel-device-plugins-gpu.yaml
+++ b/application.intel-device-plugins-gpu.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.intel-device-plugins-operator.yaml
+++ b/application.intel-device-plugins-operator.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     - CreateNamespace=true
     retry:
       backoff:

--- a/application.metacontroller.yaml
+++ b/application.metacontroller.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.metrics-server.yaml
+++ b/application.metrics-server.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.nfd.yaml
+++ b/application.nfd.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.operators.yaml
+++ b/application.operators.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.otel-collector-contour.yaml
+++ b/application.otel-collector-contour.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.otel-logs-daemonset.yaml
+++ b/application.otel-logs-daemonset.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.secret-generator.yaml
+++ b/application.secret-generator.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.snapshot-controller.yaml
+++ b/application.snapshot-controller.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.thanos-caching-bucket.yaml
+++ b/application.thanos-caching-bucket.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.thanos-index-cache.yaml
+++ b/application.thanos-index-cache.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.thanos.yaml
+++ b/application.thanos.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vendored-barman-cloud-plugin.yaml
+++ b/application.vendored-barman-cloud-plugin.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vendored-cert-manager.yaml
+++ b/application.vendored-cert-manager.yaml
@@ -23,6 +23,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vendored-cnpg.yaml
+++ b/application.vendored-cnpg.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vendored-contour.yaml
+++ b/application.vendored-contour.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vendored-kubelet-rubber-stamp.yaml
+++ b/application.vendored-kubelet-rubber-stamp.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vendored-vpa.yaml
+++ b/application.vendored-vpa.yaml
@@ -21,6 +21,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vikunja.yaml
+++ b/application.vikunja.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.vmubtkube-a.yaml
+++ b/application.vmubtkube-a.yaml
@@ -23,6 +23,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.volsync.yaml
+++ b/application.volsync.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/application.woodpecker.yaml
+++ b/application.woodpecker.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/immich/application.immich.yaml
+++ b/immich/application.immich.yaml
@@ -30,6 +30,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/kured.yaml
+++ b/kured.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/operators/clickhouse-operator.yaml
+++ b/operators/clickhouse-operator.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/operators/mongodb-community-operator.yaml
+++ b/operators/mongodb-community-operator.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s

--- a/woodpecker/application.woodpecker.yaml
+++ b/woodpecker/application.woodpecker.yaml
@@ -18,6 +18,7 @@ spec:
     - PruneLast=true
     - ServerSideApply=true
     - ApplyOutOfSyncOnly=true
+    - RespectIgnoreDifferences=true
     retry:
       backoff:
         duration: 5s


### PR DESCRIPTION
## Problem

Every Secret value committed to this repo is the placeholder base64 `++++++++` — the real values are filled in-cluster by `secret-generator`, CNPG, or ESO. Argo owns the Secret shell, never its contents.

A server-side dry-run apply (`argocd app manifests` → `kubectl diff --server-side --field-manager=argocd-controller`) across all 41 Applications found **20 Secrets whose live credentials would be overwritten with that placeholder** if Argo ever applied them:

| App | Secret | Keys at risk |
|---|---|---|
| `hyperdx` | `clickstack-secret` | `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_APP_PASSWORD`, `MONGODB_PASSWORD`, `HYPERDX_API_KEY` |
| `democratic-csi` | 4 CSI secrets | provisioner / controller-publish / controller-expand / node-publish |
| `immich`, `woodpecker`, `vmubtkube-a` | `postgres-superuser`, `postgres-*-user` | `username` |
| `kube-prometheus` | `prom-grafana`, `alertmanager-*` | `admin-password`, `admin-user`, `alertmanager.yaml` |
| `vikunja`, `clickhouse-operator`, `thanos`, `barman-cloud-plugin` | various | — |

Only `ApplyOutOfSyncOnly=true` currently hides this. Argo owns no fields under `.data`, so the structured-merge diff excludes `.data` entirely and reports `Synced` — so the resource is never applied and the mismatch stays latent instead of being corrected. That makes a performance flag load-bearing for credential safety.

## Change

- Global `resource.customizations.ignoreDifferences._Secret` ignoring `.data`/`.stringData`, with a per-Secret opt-out annotation `k8s.somemissing.info/argocd-manage-secret-data: "true"`.
- `RespectIgnoreDifferences=true` on all 41 Applications, so the ignore applies during **sync** and not only during diff.

## Why these specifics

Both details were verified against Argo's source rather than the docs:

- **`_Secret`, not `Secret`.** `convertToOverrideKey` (`util/settings/settings.go`) splits on `_`, so `_Secret` → `/Secret` (core/empty group). A bare `Secret` key hits a different branch and would **silently never match**.
- **Global rules *are* honored at sync.** The docs only mention `spec.ignoreDifferences`, but `controller/state.go` builds the normalizer via `WithDiffSettings(app.Spec.IgnoreDifferences, resourceOverrides, …)` — app-level *and* global — and `controller/sync.go` reuses that same `compareResult` for `RespectIgnoreDifferences`.
- **`RespectIgnoreDifferences` is required.** Without it, `ignoreDifferences` only silences the diff; the sync still applies the target as-is. That is [argo-cd#7478](https://github.com/argoproj/argo-cd/issues/7478) exactly: secret empty in manifest, filled in-cluster, Argo shows Synced, then sync blanks it.
- **Conditional jq is valid.** `diff_normalizer.go` wraps the expression as `del(<expr>)`, so it must be a *path* expression; the `if/then/empty/else` form was tested, including Secrets with no `annotations` key.

## Verification

- Simulated the ignore normalizer (`del(<jq>)` over both desired and live) across every Secret: **20 neutralized, 0 remaining diffs**.
- Opt-out annotation confirmed against the live `hyperdx/clickstack-secret`.
- `kubeconform`, `pluto`, and `helm render + kubeconform` pre-commit hooks pass (same as CI).

## Notes / not covered

- Verified against **gojq v0.12.19** (the version argo-cd pins), using a harness that replicates `jqNormalizerPatch.Apply` exactly. `Apply` fails the normalization if the query yields zero results ("did not return any data") or more than one ("returned multiple objects"), which the jq CLI cannot surface — both paths were checked: `del(empty)` on the opt-out branch yields exactly one object, and `del((.data, .stringData))` yields one, not two. Corpus of 46: all 20 Secrets × (desired + live) plus edge cases (absent `annotations` key, `annotations: null`, no data, `stringData`-only, opt-out `"false"`). Result: parse + compile OK, **0 errors**, 45 with `.data`/`.stringData` removed and 1 retained (the opt-out).
- With this in place, `ApplyOutOfSyncOnly=true` is no longer load-bearing and could be reconsidered separately — the docs scope it to apps with "thousands of objects" (largest here is 240), and it amplifies diff false negatives ([#28818](https://github.com/argoproj/argo-cd/issues/28818)).
- This should also clear two SSA conflicts seen in the dry-run (`kube-prometheus` `alertmanager.yaml` vs `helm`, `woodpecker` `postgres-superuser` vs `kubectl-create`), since the target is patched with live values before apply — expected, not proven.
- Still outstanding and unrelated: the `contour` certgen Job conflict, and a genuine type error in `node-feature-rules.yaml` (`intel-dp-devices`: `.spec.rules[1].matchFeatures[0].matchExpressions.class.value[0]: expected string`).

