### PR TITLE
chore(argocd): drop redundant argocd-notifications-secret ignoreDifferences

### DIFF
--- a/application.argocd.yaml
+++ b/application.argocd.yaml
@@ -34,12 +34,6 @@ spec:
     - .stringData
     - .metadata.labels
     - .metadata.annotations
-  - group: ""
-    kind: Secret
-    name: argocd-notifications-secret
-    jqPathExpressions:
-    - .data
-    - .stringData
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
The global `resource.customizations.ignoreDifferences._Secret` rule added in #298 already ignores `.data`/`.stringData` for **every** Secret, so this app-level entry for `argocd-notifications-secret` is now a no-op.

The `argocd-secret` entry is deliberately kept — it additionally ignores `.metadata.labels` and `.metadata.annotations`, which the global rule does not cover.

Pure cleanup, no behaviour change.
