### PR TITLE
fix(contour): pin defaulted fieldRef.apiVersion on the certgen Job

### DIFF
--- a/vendored/contour/kustomization.yaml
+++ b/vendored/contour/kustomization.yaml
@@ -48,3 +48,15 @@ patches:
         path: /metadata/annotations
         value:
           argocd.argoproj.io/sync-options: "Replace=true,Force=true"
+      # The API server defaults fieldRef.apiVersion to v1, and ObjectFieldSelector
+      # is x-kubernetes-map-type: atomic, so omitting it makes desired != live on a
+      # whole-value comparison. Because Replace=true writes via Update (owner
+      # "argocd-application-controller") rather than Apply, a server-side apply then
+      # conflicts on this field. Pinning the defaulted value is a semantic no-op that
+      # keeps desired == live.
+      # NOTE: these paths are index-based because the Job name embeds the Contour
+      # version, so the target cannot select by name. Recheck the indices on a
+      # vendir bump if certgen gains containers or env vars.
+      - op: add
+        path: /spec/template/spec/containers/0/env/0/valueFrom/fieldRef/apiVersion
+        value: v1


### PR DESCRIPTION
Server-side apply of the certgen Job conflicts on `.valueFrom.fieldRef`, owned by `argocd-application-controller`.

Three things combine:

1. The API server defaults `fieldRef.apiVersion` to `v1`; the vendored manifest omits it.
2. `ObjectFieldSelector` is `x-kubernetes-map-type: atomic`, so the struct compares as a single value — there is no field-level co-ownership that would let the defaulted key be ignored.
3. `Replace=true` writes this Job with the **Update** verb rather than Apply, so ownership sits under a different `{manager, operation}` identity. The conflict persists even when the manager *name* matches exactly.

Same root-cause class as #298: an API-server default inside an atomic structure.

`v1` is exactly what the API server already defaults, so this is a semantic no-op that makes desired == live — fixing the cause rather than suppressing it.

## Why `Replace=true` stays

It is load-bearing. A genuine `spec.template` change is rejected as `field is immutable` **even with `--force-conflicts`**, so dropping Replace would trade a diff-tooling annoyance for a possible hard sync failure.

Rejected alternatives: dropping `Replace=true` so ArgoCD takes Apply ownership (reintroduces the immutability failure); a one-off `--force-conflicts` apply (undone the next time Replace fires); `ignoreDifferences` on the path (hides the cause, outlives its reason).

## Impact

Latent today — ArgoCD never SSA-applies this Job, `ApplyOutOfSyncOnly` skips it while it diffs clean, and `ServerSideDiff` is off everywhere. But it breaks any `kubectl diff --server-side` of this app and would start erroring diff computation if `ServerSideDiff=true` were enabled.

## Verification

`kubectl apply --server-side --dry-run=server` over the full rendered overlay reports no conflict; `kubectl diff --server-side` exits 0. Verified certgen has exactly 1 container and 1 env var, so the index-based paths are correct today.
