### PR TITLE
fix(external-secrets): disable the redundant cert-controller

### DIFF
--- a/application.external-secrets.yaml
+++ b/application.external-secrets.yaml
@@ -44,6 +44,15 @@ spec:
           additionalLabels:
             release: prom
 
+        # cert-manager issues and rotates the webhook cert (webhook.certManager
+        # below), so the chart's bundled cert-controller is redundant. The chart
+        # already skips the cert-controller Deployment whenever certManager is
+        # enabled, but templates/servicemonitor.yaml gates the cert-controller
+        # ServiceMonitor on certController.create alone -- so without this we
+        # render a ServiceMonitor scraping a Service that is never created.
+        certController:
+          create: false
+
         webhook:
           certManager:
             enabled: true


### PR DESCRIPTION
## What this actually is

Investigating an apparent version skew (`cert-controller` on `v0.16.2` while the operator and webhook are `v2.8.0`, from a different registry) turned up something else: an **orphaned object ArgoCD cannot see**, in an active fight with cert-manager.

There is no pin anywhere — `rg -i "cert-controller|certController"` across the repo returns 0 matches. The live Deployment is a fossil from chart 0.16.2 (`helm.sh/chart: external-secrets-0.16.2`, created 2025-08-17) carrying only the legacy `app.kubernetes.io/instance` label and **no `argocd.argoproj.io/tracking-id`**. Under `resource.trackingmethod: annotation` ArgoCD treats it as unowned, never prunes it, and reports the app `Synced`/`Healthy`. The registry differs because `oci.external-secrets.io` was 0.16.2's `certController.image.repository` default.

Same-family orphans: the `serviceaccount`, `clusterrole`, `clusterrolebinding`, and 3 ReplicaSets.

## The real problem: ~166k CertificateRequests

Both the stale cert-controller and cert-manager write `Secret/external-secrets-webhook`. Every 5 minutes (`requeueInterval`) cert-controller overwrites it with its own self-signed CA and re-injects the caBundle; cert-manager re-issues.

Only 3 `CertificateRequest` objects exist at any time (cert-manager GCs them), but the **highest ordinal is `external-secrets-webhook-166488`**. The Secret is `type: Opaque` with `ca.key` — cert-controller's format, not cert-manager's `kubernetes.io/tls`. cert-manager is currently winning, but there are windows where the caBundle does not match the serving cert, which would fail `ExternalSecret`/`SecretStore` admission.

## Why this change, verified against chart 2.8.0 source

- `templates/cert-controller-deployment.yaml:1` gates on `(not .Values.webhook.certManager.enabled)`, so the Deployment was **already** skipped — but only implicitly, which is how the stale copy survived 12 chart upgrades unnoticed.
- `templates/servicemonitor.yaml:81` gates the cert-controller ServiceMonitor on `.Values.certController.create` **alone**, no certManager check, default `true` (`values.yaml:753`). So we have been rendering a ServiceMonitor scraping a Service the chart never creates.

Deliberately **not** bumping the image to v2.8.0 — that would preserve the fight loop with a newer binary. Nothing needs this component: cert-manager owns the cert (`Certificate/external-secrets-webhook` Ready=True) and the CA injection (`cert-manager.io/inject-ca-from`), and the CRD has `conversion.strategy: None` so no CRD injection is needed.

## ⚠️ Manual cleanup required after merge

ArgoCD cannot prune untracked objects. In namespace `external-secrets` delete `deployment/external-secrets-cert-controller` — **this alone stops the loop** — plus its 3 ReplicaSets, `serviceaccount/external-secrets-cert-controller`, and cluster-scoped `clusterrole` + `clusterrolebinding/external-secrets-cert-controller`.

Then confirm `Secret/external-secrets-webhook` flips to `type: kubernetes.io/tls` and the CertificateRequest ordinal stops climbing.

## Renovate

No change needed; it was never the cause. The `argocd` manager matches `application.*.yaml` and has been bumping this chart reliably (1.3.2 → … → 2.8.0 on 2026-07-18); CRDs are tracked by vendir at `v2.8.0`. There was simply no image string in the repo to bump — the skew was live-state drift, which Renovate cannot manage by definition. Pinning `certController.image` would create a new dep needing `repository`+`tag` together for the `helm-values` manager, so it is avoided.

## Optional follow-up

`orphanedResources: { warn: true }` on the `default` AppProject would surface this class of drift. With annotation tracking, anything created before the tracking-method switch and later dropped from desired state is permanently invisible.
