### PR TITLE
feat: require confirmation before pruning stateful data

### DIFF
--- a/cluster.default.yaml
+++ b/cluster.default.yaml
@@ -36,6 +36,8 @@ stringData:
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: default
   namespace: default
 spec:

--- a/hyperdx-clickhouse.yaml
+++ b/hyperdx-clickhouse.yaml
@@ -98,6 +98,8 @@ spec:
 apiVersion: clickhouse.altinity.com/v1
 kind: ClickHouseInstallation
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: hyperdx
   namespace: hyperdx
 spec:

--- a/hyperdx-mongo.yaml
+++ b/hyperdx-mongo.yaml
@@ -45,6 +45,8 @@ metadata:
 apiVersion: mongodbcommunity.mongodb.com/v1
 kind: MongoDBCommunity
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: hyperdx
   namespace: hyperdx
 spec:

--- a/immich/application.immich.yaml
+++ b/immich/application.immich.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: immich
   namespace: immich
 spec:

--- a/immich/cluster.immich.yaml
+++ b/immich/cluster.immich.yaml
@@ -162,6 +162,8 @@ spec:
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: immich
   namespace: immich
 spec:

--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -17,6 +17,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: jellyfin-media
   namespace: media
 spec:
@@ -31,6 +33,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: jellyfin-data
   namespace: media
 spec:

--- a/mumble.yaml
+++ b/mumble.yaml
@@ -16,6 +16,8 @@ type: Opaque
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: mumble-data
   namespace: default
 spec:

--- a/prowlarr.yaml
+++ b/prowlarr.yaml
@@ -17,6 +17,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: prowlarr-media
   namespace: media
 spec:
@@ -31,6 +33,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: prowlarr-data
   namespace: media
 spec:

--- a/radarr.yaml
+++ b/radarr.yaml
@@ -17,6 +17,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: radarr-media
   namespace: media
 spec:
@@ -31,6 +33,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: radarr-data
   namespace: media
 spec:

--- a/sabnzbd.yaml
+++ b/sabnzbd.yaml
@@ -17,6 +17,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: sabnzbd-media
   namespace: media
 spec:
@@ -31,6 +33,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: sabnzbd-data
   namespace: media
 spec:

--- a/selfoss.yaml
+++ b/selfoss.yaml
@@ -72,6 +72,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: selfoss-data
   namespace: default
 spec:

--- a/sonarr.yaml
+++ b/sonarr.yaml
@@ -17,6 +17,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: sonarr-media
   namespace: media
 spec:
@@ -31,6 +33,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: sonarr-data
   namespace: media
 spec:

--- a/woodpecker/cluster.woodpecker.yaml
+++ b/woodpecker/cluster.woodpecker.yaml
@@ -80,6 +80,8 @@ spec:
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=confirm
   name: woodpecker
   namespace: woodpecker
 spec:


### PR DESCRIPTION
All Applications run automated prune with selfHeal unattended, so a path change
or a bad directory.exclude edit can delete persistent data with no review step.
Prune=confirm holds the sync until the deletion is approved. It is per-resource
and does not change automation for anything else.

Database CRs are annotated in addition to their PVCs because pruning a CNPG
Cluster, ClickHouseInstallation or MongoDBCommunity deletes the PVCs it owns.

woodpecker/buildkitd-cache is excluded because it is a rebuildable cache.

Namespaces are excluded. A namespace delete cascades to its contents, but
several hold no data, so they are handled separately.
