### PR TITLE
refactor(argocd): drop ApplyOutOfSyncOnly from all Applications

### DIFF
--- a/application.argocd.yaml
+++ b/application.argocd.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.calico.yaml
+++ b/application.calico.yaml
@@ -19,7 +19,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     - CreateNamespace=true
     retry:

--- a/application.cert-manager-webhook-dnsimple.yaml
+++ b/application.cert-manager-webhook-dnsimple.yaml
@@ -35,7 +35,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.crds.yaml
+++ b/application.crds.yaml
@@ -27,7 +27,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -148,7 +148,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.external-secrets.yaml
+++ b/application.external-secrets.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     - CreateNamespace=true
     retry:

--- a/application.fluentbit.yaml
+++ b/application.fluentbit.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
       - PruneLast=true
       - ServerSideApply=true
-      - ApplyOutOfSyncOnly=true
       - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.hyperdx.yaml
+++ b/application.hyperdx.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.immich.yaml
+++ b/application.immich.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.intel-device-plugins-gpu.yaml
+++ b/application.intel-device-plugins-gpu.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.intel-device-plugins-operator.yaml
+++ b/application.intel-device-plugins-operator.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     - CreateNamespace=true
     retry:

--- a/application.metacontroller.yaml
+++ b/application.metacontroller.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.metrics-server.yaml
+++ b/application.metrics-server.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.nfd.yaml
+++ b/application.nfd.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.operators.yaml
+++ b/application.operators.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.otel-collector-contour.yaml
+++ b/application.otel-collector-contour.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.otel-logs-daemonset.yaml
+++ b/application.otel-logs-daemonset.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.secret-generator.yaml
+++ b/application.secret-generator.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.snapshot-controller.yaml
+++ b/application.snapshot-controller.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.thanos-caching-bucket.yaml
+++ b/application.thanos-caching-bucket.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.thanos-index-cache.yaml
+++ b/application.thanos-index-cache.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.thanos.yaml
+++ b/application.thanos.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vendored-barman-cloud-plugin.yaml
+++ b/application.vendored-barman-cloud-plugin.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vendored-cert-manager.yaml
+++ b/application.vendored-cert-manager.yaml
@@ -22,7 +22,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vendored-cnpg.yaml
+++ b/application.vendored-cnpg.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vendored-contour.yaml
+++ b/application.vendored-contour.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vendored-kubelet-rubber-stamp.yaml
+++ b/application.vendored-kubelet-rubber-stamp.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vendored-vpa.yaml
+++ b/application.vendored-vpa.yaml
@@ -20,7 +20,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vikunja.yaml
+++ b/application.vikunja.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.vmubtkube-a.yaml
+++ b/application.vmubtkube-a.yaml
@@ -22,7 +22,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.volsync.yaml
+++ b/application.volsync.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/application.woodpecker.yaml
+++ b/application.woodpecker.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/immich/application.immich.yaml
+++ b/immich/application.immich.yaml
@@ -31,7 +31,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/kured.yaml
+++ b/kured.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/operators/clickhouse-operator.yaml
+++ b/operators/clickhouse-operator.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/operators/mongodb-community-operator.yaml
+++ b/operators/mongodb-community-operator.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:

--- a/woodpecker/application.woodpecker.yaml
+++ b/woodpecker/application.woodpecker.yaml
@@ -17,7 +17,6 @@ spec:
     syncOptions:
     - PruneLast=true
     - ServerSideApply=true
-    - ApplyOutOfSyncOnly=true
     - RespectIgnoreDifferences=true
     retry:
       backoff:


### PR DESCRIPTION
The option is intended for applications with thousands of objects. The largest
app here has 240 resources and the cluster totals 1014 across 41 apps, so the
saving is small.

It skips every resource the diff reports as Synced, so a diff false negative
leaves a resource unapplied indefinitely (argo-cd#28818). 18 of 129 CRDs use
x-kubernetes-preserve-unknown-fields, including applications.argoproj.io. For
the same reason selfHeal cannot correct such a resource, which is why the
pki-ca ExternalSecret drift persisted.

The option was also the only thing preventing ArgoCD from applying the 20
Secrets whose git values are the placeholder base64 `++++++++`. Those now
depend on RespectIgnoreDifferences (#298) patching live values into the target
before apply. That path has not yet run during a real sync, so Secret values
need checking after the first sync.

Resources predating the resource.trackingmethod: annotation switch still carry
the legacy argocd.argoproj.io/instance label and were never re-applied because
they diffed clean. The first sync migrates them to tracking-id annotations.
