### PR TITLE
feat: deploy otel-agent-trace-connector at agents-otel.k8s.somemissing.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,23 @@ Two DNS zones, split by audience:
 
 - **`*.apps.somemissing.info`** — internet-facing services, exposed through
   the Contour edge (HTTPProxy) with public DNS.
-- **`*.k8s.somemissing.info`** — internal/LAN-only services. These resolve to
-  routable ServiceIPs via the `external-dns.alpha.kubernetes.io/hostname`
-  annotation on a plain ClusterIP Service (external-dns writes the
-  `k8s.somemissing.info` zone over RFC2136) and are not reachable from the
-  internet.
+- **`*.k8s.somemissing.info`** — internal/LAN-only services, reachable from the
+  home network but not from the internet. These resolve to routable ServiceIPs
+  via the `external-dns.alpha.kubernetes.io/hostname` annotation on a plain
+  ClusterIP Service (external-dns writes the `k8s.somemissing.info` zone over
+  RFC2136).
+
+  **Why a bare ClusterIP is reachable from off-cluster:** Calico BGP-peers with
+  the default gateway (`172.16.3.254`, AS 64512 on both sides) and advertises
+  the Service CIDR `192.168.208.0/20` to it — see the `BGPConfiguration` /
+  `BGPPeer` / `BGPFilter` resources in `application.calico.yaml`. The gateway
+  therefore routes ClusterIPs straight to the nodes, so LAN clients connect to
+  the ServiceIP directly. **No LoadBalancer, NodePort, or Ingress is needed to
+  expose a service on the LAN** — reach for one only when you actually want L7
+  features, and prefer the `*.apps` Contour edge for those. (A separate
+  `192.168.240.0/28` pool is advertised for the few LoadBalancer Services that
+  do exist, e.g. syslog ingest, which needs `externalTrafficPolicy: Local` to
+  preserve the sender's source IP.)
 
 Both zones get **publicly-trusted Let's Encrypt certificates** from the
 `cert-manager-webhook-dnsimple-production` ClusterIssuer. DNS-01 validation

--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -62,6 +62,19 @@ spec:
                   error_mode: ignore
                   span:
                     - 'resource.attributes["service.name"] == "claude-code"'
+              # Coding-agent telemetry arriving via agents-otel.k8s.somemissing.info
+              # (otel-agent-trace-connector.yaml) is kept at 100%: these are
+              # low-volume, individually interesting traces, and the canonical
+              # invoke_agent/chat/execute_tool tree is useless if a random 1% of
+              # its turns survive. The tag is applied by that collector's
+              # resource/coding_agent processor on both the raw vendor
+              # telemetry and the canonical traces it emits.
+              - name: coding-agent
+                type: ottl_condition
+                ottl_condition:
+                  error_mode: ignore
+                  span:
+                    - 'resource.attributes["telemetry.source"] == "coding-agent"'
               - name: random
                 type: probabilistic
                 probabilistic: {sampling_percentage: 1}

--- a/docs/claude-code-otel-project-attribution.md
+++ b/docs/claude-code-otel-project-attribution.md
@@ -10,7 +10,9 @@ workflow, terminal, and model today.
 
 Claude Code emits spans under `ServiceName = claude-code` (scope
 `com.anthropic.claude_code.tracing`) with span types `interaction`,
-`llm_request`, `tool`, `tool.execution`, `tool.blocked_on_user`. None of the
+`llm_request`, `tool`, `tool.execution`, `tool.blocked_on_user`. (These are
+also the input to the canonical coding-agent trace shape — see
+[coding-agent traces](./coding-agent-traces.md).) None of the
 span attributes nor the `ResourceAttributes` identify which project/repo the
 session ran in — `ResourceAttributes` carries only `host.arch`, `os.type`,
 `os.version`, `service.name`, `service.version`.

--- a/docs/coding-agent-traces.md
+++ b/docs/coding-agent-traces.md
@@ -1,0 +1,99 @@
+# Coding-agent traces (`agents-otel.k8s.somemissing.info`)
+
+`otel-agent-trace-connector.yaml` deploys
+[nijave/otel-agent-trace-connector](https://github.com/nijave/otel-agent-trace-connector),
+a custom OCB-built Collector distribution carrying the `coding_agent` connector.
+It gives Codex and Claude Code a **single comparable trace shape**:
+
+```text
+invoke_agent <agent>
+├── chat <model>
+└── execute_tool <tool>
+```
+
+- **Codex** emits structured `codex.*` OTLP **logs**, not traces. The connector
+  correlates them in memory into one canonical trace per user turn.
+- **Claude Code** already emits a native span tree
+  (`claude_code.interaction` → `llm_request` / `tool`, see
+  [project attribution](./claude-code-otel-project-attribution.md)). The
+  connector preserves that hierarchy and renames spans/attributes into the same
+  vocabulary.
+
+Raw vendor telemetry is forwarded **in parallel, unmodified**, so the original
+Codex logs and Claude Code spans stay queryable in HyperDX alongside the
+canonical traces.
+
+## Where it sits
+
+```text
+Codex / Claude Code
+  └─ agents-otel.k8s.somemissing.info:4317 (gRPC) / :4318 (HTTP)   [this service]
+       └─ otel-collector.k8s.somemissing.info:4317                 [monitoring]
+            └─ hyperdx-otel-collector.hyperdx:4317 → ClickHouse
+```
+
+The second hop is the same collector `projectcontour`'s `otel-collector`
+forwards to.
+
+## Pointing an agent at it
+
+TLS is a public Let's Encrypt cert (DNS-01), so no CA needs trusting. The
+hostname is LAN-only — see "DNS zones and TLS" in the [README](../README.md).
+
+> **Use the signal-specific endpoint variables.** This collector serves logs
+> and traces only. The downstream `otel-collector` sets `metrics: null`, so the
+> cluster does not ingest OTLP metrics at all — a generic
+> `OTEL_EXPORTER_OTLP_ENDPOINT` will fail on the metrics service. Set
+> `OTEL_METRICS_EXPORTER=none`.
+
+Claude Code — native trace export is still beta and off by default:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+export OTEL_METRICS_EXPORTER=none
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://agents-otel.k8s.somemissing.info:4318/v1/traces
+```
+
+Claude Code's *logs* carry prompt/tool content when the `OTEL_LOG_*` content
+gates are enabled; leave them unset. Its traces are what the connector
+normalizes.
+
+Codex reads **user-level** `~/.codex/config.toml` only — it ignores
+project-local `[otel]` blocks. Codex emits its telemetry as OTLP **logs**:
+
+```toml
+[otel]
+environment = "homelab"
+log_user_prompt = false
+exporter = { otlp-http = { endpoint = "https://agents-otel.k8s.somemissing.info:4318/v1/logs", protocol = "binary" } }
+```
+
+Keep `log_user_prompt = false`. The connector never copies prompt text, tool
+arguments, or tool output into generated spans, but the **raw** Codex logs are
+forwarded verbatim, so anything Codex logs does reach ClickHouse.
+
+## Sampling
+
+These traces are exempt from the downstream 1% probabilistic tail sampling. The
+collector tags everything it forwards with the resource attribute
+`telemetry.source=coding-agent` (its `resource/coding_agent` processor), and the
+`coding-agent` `tail_sampling` policy in `application.otel-collector.yaml`
+always-samples on that tag. Both the raw and the canonical output carry it.
+
+If you add another hop between here and HyperDX, it needs the same exemption.
+
+## Operational limits
+
+- **Single replica, `strategy: Recreate`** — deliberate. Codex turn correlation
+  is in-memory; two replicas would split one turn's log records into two
+  incomplete traces. The state does not survive a restart, so a roll or a crash
+  drops in-flight turns. Completed traces are unaffected.
+- `max_active_turns: 500` bounds that state. Turns finalize on a quiet
+  `reorder_window` (30s) after `response.completed`, or at `turn_timeout` (10m).
+- The connector is at **development stability** upstream; span names and
+  attributes may change between releases.
+- The image tag is pinned and Renovate-tracked. Releases are cut by tagging the
+  upstream repo, which publishes `ghcr.io/nijave/otel-agent-trace-connector`.

--- a/docs/coding-agent-traces.md
+++ b/docs/coding-agent-traces.md
@@ -62,14 +62,28 @@ gates are enabled; leave them unset. Its traces are what the connector
 normalizes.
 
 Codex reads **user-level** `~/.codex/config.toml` only — it ignores
-project-local `[otel]` blocks. Codex emits its telemetry as OTLP **logs**:
+project-local `[otel]` blocks (it warns and drops an `otel` key found in a
+project `.codex/config.toml`).
 
 ```toml
 [otel]
-environment = "homelab"
+environment = "production"
 log_user_prompt = false
-exporter = { otlp-http = { endpoint = "https://agents-otel.k8s.somemissing.info:4318/v1/logs", protocol = "binary" } }
+exporter       = { otlp-grpc = { endpoint = "https://agents-otel.k8s.somemissing.info:4317" } }
+trace_exporter = { otlp-grpc = { endpoint = "https://agents-otel.k8s.somemissing.info:4317" } }
 ```
+
+`otel.exporter` is the **logs** exporter and defaults to `"none"`. Codex emits
+its `codex.*` events as OTLP *logs*, not traces, so **this is the one the
+connector needs** — `trace_exporter` alone produces no canonical Codex traces.
+
+`trace_exporter` is optional here. Codex's native spans are not normalized (the
+Claude edge drops any resource that has no `claude_code.`-prefixed span, so
+there is no duplication), but pointing it at this collector still gets those
+spans the 100% sampling exemption.
+
+`metrics_exporter` defaults to Statsig rather than OTLP, so the metrics caveat
+above does not apply to Codex unless you set it explicitly.
 
 Keep `log_user_prompt = false`. The connector never copies prompt text, tool
 arguments, or tool output into generated spans, but the **raw** Codex logs are

--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -1,0 +1,247 @@
+---
+# Coding-agent telemetry ingest (github.com/nijave/otel-agent-trace-connector).
+#
+# A custom OCB-built Collector distribution carrying the `coding_agent`
+# connector, which turns Codex's structured OTLP logs into one trace per user
+# turn and normalizes Claude Code's native span tree into the same canonical
+# vocabulary:
+#
+#   invoke_agent <agent>
+#   ├── chat <model>
+#   └── execute_tool <tool>
+#
+# Agents point at agents-otel.k8s.somemissing.info; raw vendor telemetry and
+# the canonical traces are both forwarded to otel-collector.k8s.somemissing.info
+# -- the same collector projectcontour's otel-collector forwards to.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: otel-agent-trace-connector
+  namespace: monitoring
+spec:
+  secretName: otel-agent-trace-connector-tls
+  commonName: &cn agents-otel.k8s.somemissing.info
+  dnsNames:
+    - *cn
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-webhook-dnsimple-production
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-trace-connector
+  namespace: monitoring
+data:
+  config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+            tls:
+              cert_file: /tls/tls.crt
+              key_file: /tls/tls.key
+          http:
+            endpoint: 0.0.0.0:4318
+            tls:
+              cert_file: /tls/tls.crt
+              key_file: /tls/tls.key
+
+    connectors:
+      # Codex: stateful correlation of codex.* logs into one trace per turn.
+      # A turn with a response.completed event is finalized once reorder_window
+      # is quiet; one without is finalized by turn_timeout. max_active_turns
+      # bounds memory -- 500 is generous for a handful of concurrent agents and
+      # keeps the worst case well inside the pod's memory limit (the upstream
+      # README's 10000 assumes a far larger fleet).
+      coding_agent:
+        turn_timeout: 10m
+        reorder_window: 30s
+        max_active_turns: 500
+        max_events_per_turn: 1000
+      # Claude Code: stateless normalization of its native span tree.
+      coding_agent/claude:
+
+    processors:
+      # Tags everything this collector forwards so the downstream collector can
+      # exempt it from tail sampling. Applied on both the ingest pipelines and
+      # the canonical pipeline: the connectors copy the resource through, but
+      # tagging the output too means the exemption holds regardless of how a
+      # future connector version builds its resource.
+      resource/coding_agent:
+        attributes:
+          - key: telemetry.source
+            value: coding-agent
+            action: upsert
+      batch:
+        send_batch_size: 1024
+        timeout: 5s
+
+    exporters:
+      otlp_grpc:
+        endpoint: otel-collector.k8s.somemissing.info:4317
+        tls:
+          insecure: false
+
+    service:
+      extensions: [health_check]
+      telemetry:
+        metrics:
+          readers:
+            # Defaults to localhost:8888, which the ServiceMonitor cannot reach.
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 0.0.0.0
+                    port: 8888
+      pipelines:
+        # Raw vendor telemetry is forwarded as-is alongside the canonical
+        # traces, so the original Codex logs and Claude Code spans stay
+        # queryable in HyperDX.
+        logs/vendor:
+          receivers: [otlp]
+          processors: [resource/coding_agent, batch]
+          exporters: [otlp_grpc, coding_agent]
+        traces/native:
+          receivers: [otlp]
+          processors: [resource/coding_agent, batch]
+          exporters: [otlp_grpc, coding_agent/claude]
+        traces/canonical:
+          receivers: [coding_agent, coding_agent/claude]
+          processors: [resource/coding_agent, batch]
+          exporters: [otlp_grpc]
+        # No metrics pipeline, deliberately: the downstream otel-collector sets
+        # `metrics: null`, so this cluster does not ingest OTLP metrics at all
+        # (the claude-code dashboards are built from otel_traces). Agents must
+        # therefore use the signal-specific OTEL_EXPORTER_OTLP_*_ENDPOINT
+        # variables, or set OTEL_METRICS_EXPORTER=none -- a generic endpoint
+        # pointed here will fail on the metrics service. See
+        # docs/coding-agent-traces.md.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-agent-trace-connector
+  namespace: monitoring
+  annotations:
+    # Roll on config edits and when cert-manager renews the cert (~every 60d).
+    reloader.stakater.com/auto: "true"
+spec:
+  # Single replica, and Recreate rather than RollingUpdate. The Codex side of
+  # the connector correlates a turn from many log records held in memory; two
+  # pods would split one turn's events across two incomplete traces, and the
+  # state does not survive a restart either way. A dropped turn during a roll
+  # is the accepted cost -- see the upstream design doc's operational limits.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: otel-agent-trace-connector
+  template:
+    metadata:
+      labels:
+        app: otel-agent-trace-connector
+    spec:
+      containers:
+        - name: collector
+          # renovate: datasource=docker depName=ghcr.io/nijave/otel-agent-trace-connector
+          image: ghcr.io/nijave/otel-agent-trace-connector:v0.1.0
+          imagePullPolicy: IfNotPresent
+          args: ["--config=/conf/config.yaml"]
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: health
+              containerPort: 13133
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+              readOnly: true
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: otel-agent-trace-connector
+        - name: tls
+          secret:
+            secretName: otel-agent-trace-connector-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-agent-trace-connector
+  namespace: monitoring
+  labels:
+    app: otel-agent-trace-connector
+  annotations:
+    # ClusterIPs are routable on the LAN (Calico advertises the Service CIDR to
+    # the gateway over BGP), so a plain ClusterIP plus this annotation is all an
+    # agent outside the cluster needs -- see "DNS zones and TLS" in README.md.
+    external-dns.alpha.kubernetes.io/hostname: agents-otel.k8s.somemissing.info
+spec:
+  type: ClusterIP
+  selector:
+    app: otel-agent-trace-connector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: otel-agent-trace-connector
+  namespace: monitoring
+  labels:
+    release: prom
+spec:
+  selector:
+    matchLabels:
+      app: otel-agent-trace-connector
+  endpoints:
+    - port: metrics
+      interval: 30s


### PR DESCRIPTION
Deploys [nijave/otel-agent-trace-connector](https://github.com/nijave/otel-agent-trace-connector)
— a custom OCB-built Collector distribution carrying the `coding_agent`
connector — so Codex and Claude Code produce one comparable canonical trace per
user turn:

```text
invoke_agent <agent>
├── chat <model>
└── execute_tool <tool>
```

Codex only emits structured `codex.*` OTLP **logs**, which the connector
correlates in memory into a trace. Claude Code's native span tree is preserved
and renamed into the same vocabulary. Raw vendor telemetry is forwarded in
parallel, unmodified, so the originals stay queryable in HyperDX.

> [!IMPORTANT]
> **Blocked on nijave/otel-agent-trace-connector#5** merging and a `v0.1.0`
> tag. That PR adds the OTLP exporter (the distribution shipped only `awss3`
> and `file` exporters, so it physically could not forward to another
> Collector) and publishes the image (releases shipped binary archives only —
> there was nothing to deploy). Until then the pinned image tag does not exist.

## Ingest

`agents-otel.k8s.somemissing.info` is a plain **ClusterIP** + external-dns
annotation — ServiceIPs are routable on the LAN, so no LoadBalancer or Ingress
is involved — with a Let's Encrypt cert terminated inside the collector.
This mirrors `application.otel-collector.yaml`. It forwards to
`otel-collector.k8s.somemissing.info:4317`, the same collector
`projectcontour`'s `otel-collector` forwards to.

## Sampling

That downstream collector tail-samples anything unmatched at **1%**, which
would shred these turn traces. This collector tags everything it forwards with
the resource attribute `telemetry.source=coding-agent`, and a matching
always-sample `tail_sampling` policy keeps them at 100%.

HyperDX's collector does no sampling, so the main `otel-collector` is the only
intermediate hop that needed a change.

## Notable decisions

- **Single replica, `strategy: Recreate`.** Codex turn correlation is in-memory;
  two pods would split one turn's log records into two incomplete traces. State
  does not survive a restart either way, so a roll drops in-flight turns.
- **`max_active_turns: 500`**, not the upstream README's 10000, which assumes a
  much larger fleet and would not fit the pod's memory limit.
- **No metrics pipeline, deliberately.** The downstream collector sets
  `metrics: null` — this cluster does not ingest OTLP metrics at all (the
  claude-code dashboards are built from `otel_traces`). Agents must use the
  signal-specific `OTEL_EXPORTER_OTLP_*_ENDPOINT` variables; a generic endpoint
  pointed here fails on the metrics service. Documented rather than papered
  over with a pipeline that would fail downstream anyway.

## Docs

- New `docs/coding-agent-traces.md`: architecture, agent-side config (verified
  against the upstream e2e Compose/`config.toml`, not written from memory), the
  sampling contract, and operational limits.
- `README.md` "DNS zones and TLS" now explains **why** a bare ClusterIP is
  reachable off-cluster: Calico BGP-peers with the gateway (`172.16.3.254`, AS
  64512) and advertises the Service CIDR `192.168.208.0/20`. The README
  previously asserted routable ServiceIPs without the mechanism.

## Validation

- `.ci/validate.sh` — 340 resources valid; `validate-pluto.sh` and
  `validate-helm.sh` (21 Helm apps) pass. Pre-commit hooks green.
- The embedded collector config was extracted from the ConfigMap and run
  through `otelcol-coding-agents validate` on a locally built distribution.
- **Booted it for real** with a self-signed cert at the mounted path: both TLS
  OTLP listeners start, an OTLP/HTTPS POST is accepted, and the pipelines hand
  off to the `otlp_grpc` exporter.
- **Verified the sampling tag end-to-end**: pushed a Claude Code native trace
  through the connector and confirmed `telemetry.source=coding-agent` appears on
  the resource attributes of *both* the raw native and the canonical output, and
  that the canonical tree renders as `invoke_agent claude_code` / `chat
  claude-opus-5` / `execute_tool`.
- The modified `tail_sampling` block was validated against
  `otel/opentelemetry-collector-contrib:0.156.0` — the exact image running in
  `monitoring`.

Not verified: the image itself (does not exist yet) and therefore the running
pod. Worth watching the first rollout for cert-mount and DNS-record creation.