### PR TITLE
fix(ci): stop sync-schemas.sh operating on the outer repo from a hook

### DIFF
--- a/.ci/sync-schemas.sh
+++ b/.ci/sync-schemas.sh
@@ -16,6 +16,21 @@ set -euo pipefail
 # blob-less sparse clone holding only the requested version's strict schemas;
 # a cluster upgrade just sparse-checkout-adds the new directory.
 
+# Every git call below targets a mirror clone via `git -C`. That flag changes
+# directory but does NOT clear the environment, and GIT_DIR takes precedence
+# over repository discovery — so when git exports it, all of them silently
+# operate on *this* repo instead of the mirror.
+#
+# Git exports an absolute GIT_DIR to hooks when the checkout is a linked
+# worktree (in a plain checkout it leaves GIT_DIR unset, which is why this only
+# ever bit inside a worktree). Via the pre-commit hooks that means:
+#   - `sparse-checkout set` writes to the outer worktree, emptying it
+#     ("You are in a sparse checkout with 0% of tracked files present");
+#   - `reset --hard origin/main` on a warm mirror moves the outer worktree's
+#     branch pointer, discarding commits.
+# Both reproduced against git 2.x. Unset the discovery vars so `-C` is honored.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR
+
 MIRROR=${SCHEMA_MIRROR:-.tmp/schemas}
 KJS="$MIRROR/kubernetes-json-schema"
 CRDS="$MIRROR/CRDs-catalog"


### PR DESCRIPTION
Hit while running the pre-commit hooks from a git worktree: the working tree
emptied itself mid-commit —

```
You are in a sparse checkout with 0% of tracked files present.
```

## Root cause

`git -C` changes directory but **does not clear the environment**, and `GIT_DIR`
takes precedence over repository discovery. Git exports an **absolute** `GIT_DIR`
to hooks when the checkout is a **linked worktree**; in a plain checkout it
leaves `GIT_DIR` unset, which is why this only ever bit inside a worktree.

So under the pre-commit hooks, every `git -C "$MIRROR" ...` in this script
silently retargeted the repo running the hook instead of the mirror clone.

## Consequences

Both reproduced against a scratch repo + worktree:

| Call | What it actually did |
| --- | --- |
| `sparse-checkout set/add` | Wrote the schema-directory patterns to the **outer worktree's** `info/sparse-checkout` and set `core.sparseCheckout=true` → emptied the working tree |
| `reset --hard origin/main` | Moved the **outer worktree's branch pointer** (verified: 2 commits → 1), discarding commits |

Only the first was hit, because the mirror was cold. The `reset --hard` path is
the *common* one once a mirror is synced, so this was live data-loss exposure.

A third, quieter symptom: the mirror never worked in a worktree at all.
`.tmp/schemas/kubernetes-json-schema/` contained only `.git` — no schema
directories — so `validate.sh` silently fell back to remote schema locations,
losing the offline/deterministic behaviour this script exists to provide.

## Fix

Unset the discovery variables at the top of the script so `-C` is honored.
One line; no behaviour change when `GIT_DIR` was already absent.

## Verification

Ran the pre-commit hook's entry verbatim from a linked worktree with `GIT_DIR`
set exactly as git sets it:

- **Cold mirror:** validation passes; outer sparse-checkout **clean**; all 95
  working-tree entries intact; `core.sparseCheckout` still false. The mirror now
  materializes `master-standalone-strict` and `v1.36.3-standalone-strict` — it
  previously held only `.git`.
- **Warm mirror** (second run, exercises the `fetch` / `reset --hard` paths):
  outer `HEAD` unchanged, no leak, working tree clean.

Also confirmed the negative case in a scratch repo — with `GIT_DIR` set and
without the fix, `sparse-checkout set` lands in the outer worktree and
`reset --hard HEAD~1` rewinds the outer branch; with the fix, both land in the
mirror.

Found while working on #305.