### PR TITLE
feat(woodpecker): run 4 concurrent workflows per agent

### DIFF
--- a/woodpecker/application.woodpecker.yaml
+++ b/woodpecker/application.woodpecker.yaml
@@ -105,6 +105,21 @@ spec:
           env:
             WOODPECKER_SERVER: woodpecker-server:9000
             WOODPECKER_BACKEND: kubernetes
+            # Concurrent workflows this agent will lease.  Upstream defaults to
+            # 1, and with replicaCount: 1 that made the whole cluster's CI a
+            # strictly serial queue.  Pipelines average ~100s, so the ceiling
+            # was ~36/hour against a push rate that peaks near 33/hour -- ~92%
+            # utilization, where queue delay grows without bound.  Observed
+            # waits hit 843s before this was raised.  4 puts the ceiling around
+            # 144/hour (~23% utilization) with room for bursts.
+            #
+            # Scaling this costs memory on the agent (it multiplexes a log
+            # stream per running workflow -- see the limit below) and multiplies
+            # concurrent iSCSI PVC attach/detach churn on democratic-csi, since
+            # each workflow provisions its own WOODPECKER_BACKEND_K8S_VOLUME_SIZE
+            # workspace.  Node CPU is not the constraint; the busiest node sits
+            # near 40%.
+            WOODPECKER_MAX_WORKFLOWS: "4"
             WOODPECKER_BACKEND_K8S_NAMESPACE: woodpecker
             # Workspace PVCs come from the only StorageClass we have,
             # zfs-generic-iscsi-csi (democratic-csi iSCSI), which is
@@ -168,6 +183,9 @@ spec:
           resources:
             requests:
               cpu: 25m
-              memory: 64Mi
+              memory: 128Mi
+            # Headroom for WOODPECKER_MAX_WORKFLOWS concurrent log streams.  At
+            # the old serial capacity 256Mi was ample; running 4 workflows at
+            # once scales the agent's buffering roughly linearly.
             limits:
-              memory: 256Mi
+              memory: 512Mi


### PR DESCRIPTION
## Why

Woodpecker pipelines were queueing for up to ~15 minutes. Root cause: the agent never set `WOODPECKER_MAX_WORKFLOWS`, so it took upstream's default of **1**. With `replicaCount: 1`, the entire cluster's CI was a strictly serial queue across all three repos.

```
 id |        name        | capacity | no_schedule
  1 | woodpecker-agent-0 |        1 | f
```

At the time of investigation, 5 tasks sat unassigned (`agent_id = 0`) behind 1 running workflow.

## The math

| | |
|---|---|
| Avg pipeline runtime (7d) | 93s (vmubtkube-a), 112s (python-envoy-authz) |
| Throughput ceiling at capacity 1 | ~36 pipelines/hour |
| Observed push rate at peak | 29 pipelines in 53 min ≈ 33/hour |
| Utilization | **~92%** |

Above ~90% utilization queue delay grows without bound, which is what the numbers showed — queue wait over 24h averaged **143s**, max **843s**, and the then-running pipeline had waited **940s** before starting.

Capacity 4 lifts the ceiling to ~144/hour, dropping utilization to ~23%.

## Changes

- `WOODPECKER_MAX_WORKFLOWS: "4"` on the agent
- Agent memory limit 256Mi → 512Mi, request 64Mi → 128Mi — the agent multiplexes a log stream per running workflow, so buffering scales with concurrency

## Risk / blast radius

- **Node CPU is not the constraint.** Busiest node runs ~41%, `a24` is at 9%.
- **The hard `task-uuid` podAffinity is unaffected.** It co-locates step pods *within* one workflow onto a single node for the shared RWO workspace PVC. That constraint is per-workflow and still holds when workflows run in parallel.
- **Storage churn is the real cost.** Up to 4 concurrent 10G iSCSI workspace PVCs instead of 1, so more provision/attach/detach load on democratic-csi. The pre-existing `FUTURE:` note about moving to RWX/NFS workspaces becomes more worthwhile.

## Not addressed (separate noise, not stalls)

Two log patterns look alarming but are benign, and this PR intentionally leaves them alone:

- `failed to extend workflow lease: queue: task not found` — fires at the exact second a pipeline *finishes*. Pipeline 1308 finished `00:15:01` **success**; error logged `00:15:02`. The `killed` cases were cancelled by `cancel_previous_pipeline_events`, working as intended. This is a different failure mode than the Multi-Attach stall the existing code comment describes.
- `could not create pipeline from webhook: 'when' filters filtered out all steps` — pushes touching no paths matching any step's `when`, logged at `error` level. Pure noise.

## Verification

`helm template` against chart 3.6.5 with this repo's `valuesObject` renders the intended agent StatefulSet:

```
resources: {"limits": {"memory": "512Mi"}, "requests": {"cpu": "25m", "memory": "128Mi"}}
ENV: {'name': 'WOODPECKER_MAX_WORKFLOWS', 'value': '4'}
```

kubeconform and pluto pre-commit checks passed. Not yet applied to the cluster — effect on queue wait should be confirmed after Argo syncs.