### PR TITLE
feat(python-envoy-authz): adopt OTel tracing and the HTTP health port

### DIFF
--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -82,10 +82,26 @@ spec:
               secretKeyRef:
                 name: ca-ha-homelab-somemissing-info-tls
                 key: ca.crt
+          # Tracing is opt-in in the app: it stays off until
+          # OTEL_EXPORTER_OTLP_ENDPOINT is set. Export to the in-namespace
+          # collector (application.otel-collector-contour.yaml, plaintext OTLP
+          # gRPC) — the same one Envoy sends its spans to, so an ext_authz
+          # Check lands as a child of the Envoy span for that request.
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://otel-collector.projectcontour:4317"
+          - name: OTEL_SERVICE_NAME
+            value: "python-envoy-authz"
+          # Keep the /healthz startup probe out of traces. Honored by the
+          # FastAPI instrumentor; matched as a substring of the request path.
+          - name: OTEL_PYTHON_FASTAPI_EXCLUDED_URLS
+            value: "healthz"
         ports:
-          - name: http
+          - name: grpc
             protocol: TCP
             containerPort: 5000
+          - name: http
+            protocol: TCP
+            containerPort: 5001
         livenessProbe:
           exec:
             command: ["grpc_health_probe", "-addr=:5000", "-tls", "-tls-no-verify"]
@@ -96,6 +112,14 @@ spec:
             command: ["grpc_health_probe", "-addr=:5000", "-tls", "-tls-no-verify"]
           initialDelaySeconds: 3
           periodSeconds: 5
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 5001
+            scheme: HTTPS
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 6
         volumeMounts:
           - name: certificate
             mountPath: /var/lib/tls
@@ -117,6 +141,10 @@ spec:
       port: 443
       protocol: TCP
       targetPort: 5000
+    - name: http
+      port: 5001
+      protocol: TCP
+      targetPort: 5001
   selector:
     app: python-envoy-authz
 ---


### PR DESCRIPTION
Syncs the live deployment with the config surface python-envoy-authz has on `main` today. Two upstream changes landed after this manifest was last touched and were never picked up here:

- `feat/in-process-https-server` (#7) — the app now runs a uvicorn HTTPS server on 5001 alongside the gRPC listener, serving `/healthz`.
- `feat/otel-support` (#8) — opt-in OTLP tracing, off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set.

Upstream's example manifest (`k8s.yaml`) shows the intended shape; this is that, adapted to the real namespace/collector.

## Changes

- **Tracing on.** `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.projectcontour:4317` — the in-namespace collector from `application.otel-collector-contour.yaml`, which Envoy already exports to. Same collector means an ext_authz `Check` span attaches to the Envoy span for the same request (Envoy forwards `traceparent` to ext_authz; the gRPC server instrumentor extracts it). Plaintext OTLP gRPC, so `http://`; the `monitoring` collector requires TLS and is an extra hop. `OTEL_PYTHON_FASTAPI_EXCLUDED_URLS=healthz` keeps the 5s probe out of traces.
- **Port 5001 exposed** on the container and the Service, plus a `startupProbe` on `GET /healthz` (HTTPS, `failureThreshold: 6`) so a rollout doesn't advance on a pod whose HTTP side never came up.
- **Renamed the 5000 container port** `http` → `grpc`. It has always been the gRPC listener; the name was wrong and now collides. Service `targetPort`s here are numeric, so nothing resolves it by name.

## Verification

- `.ci/validate.sh` (kubeconform, strict) — passes; pre-commit hooks passed on commit.
- `kubectl apply --server-side --dry-run=server` against the live cluster — all 7 objects accepted.
- Ran the current `:latest` image in-cluster as a throwaway pod: `envoy_authz.telemetry` is present (the running pods predate it — they're on an older digest and will pick it up on this rollout), `setup_telemetry()` returns a real `TracerProvider`, TCP to `otel-collector.projectcontour:4317` connects, a test span records, and the batch exporter shuts down clean.
- Confirmed a running pod already answers `https://localhost:5001/healthz` with `{"status":"ok"}`, so exposing the port and probing it can't regress the rollout.

Note: spans are subject to the gateway collector's 1% probabilistic tail sampling (errors always kept), so expect authz traces to be sparse rather than absent.

## Not in scope

`HA_CRL` — `config.py` takes it optionally, but the `pki-crl` ExternalSecret for `projectcontour` is Phase 7 of the homelab-pki plan and isn't deployed. Separate PR.

The mTLS→OAuth2 federation work (`providers.yaml`, OP endpoints, new env vars) is still on unmerged branches — nothing to wire up yet.