### PR TITLE
perf(democratic-csi): raise provisioner worker-threads to 16

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -176,6 +176,10 @@ spec:
           externalProvisioner:
             extraArgs:
               - --http-endpoint=:8080
+              # default 10; modest headroom for burst PVC churn (Woodpecker CI).
+              # NAS sshd MaxSessions raised to 64 to absorb the concurrency;
+              # kept conservative so concurrent zfs/targetcli ops don't contend.
+              - --worker-threads=16
           externalAttacher:
             extraArgs:
               - --http-endpoint=:8081


### PR DESCRIPTION
## What

Bump `csi-provisioner` `--worker-threads` from the default `10` to `16` on the democratic-csi controller.

## Why

Telemetry (HyperDX log pairing of democratic-csi RPCs, trailing 24h) showed:

- `csi-provisioner` defaults `--worker-threads` to `10`, capping concurrent `CreateVolume`/`DeleteVolume` at ~9 in-flight (observed peak).
- Woodpecker CI drives burst PVC churn — ~9 create + 9 delete every 30 min — which occasionally spiked past the NAS sshd `MaxSessions=10` ceiling, producing `(SSH) Channel open failure` errors on `CreateVolume` (~7/day).

The NAS `sshd` `MaxSessions` has been raised to `64`, removing the SSH bottleneck. This bumps the provisioner worker pool to `16` for modest headroom during bursts.

## Why 16 and not higher

- Steady-state controller utilization is ~4% (bursts already complete well within their 30-min window), so this is headroom, not backlog relief.
- Going higher (e.g. 32) risks overloading the ZFS/`targetcli` backend on the NAS — `targetcli` is locky under concurrency and per-op latency would rise. 16 is a conservative middle ground.

## Notes

- Scope: `controller.externalProvisioner` only. `attacher`/`resizer`/`snapshotter` unaffected.
- Validates clean through pre-commit kubeconform / pluto / helm-render checks.