### PR TITLE
chore(democratic-csi): set controller driver logLevel to verbose

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -190,6 +190,11 @@ spec:
             extraArgs:
               - --http-endpoint=:8083
           driver:
+            # TEMP (perf investigation): verbose surfaces per-command zfs/targetcli
+            # timing (ZfsProcessManager/TargetCLI command lines) to split CreateVolume
+            # Phase A; node DaemonSet intentionally left at info to limit log volume.
+            # Revert via stacked PR once analysis is captured.
+            logLevel: verbose
             image:
               # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
               # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate


### PR DESCRIPTION
## What

Set `controller.driver.logLevel: verbose` (renders as `--log-level=verbose` on the controller driver container, `controller.yaml:108`). Node DaemonSet left at `info`.

## Why

Telemetry (HyperDX log pairing) showed **~94% of CreateVolume time is in Phase A** (zvol creation + iSCSI target setup), but at `info` level democratic-csi only logs the RPC boundaries — the per-command work is opaque. `verbose` surfaces:

- `ZfsProcessManager command: <cmd>` — every `zfs` op (`zfs create`, `zfs set`, …) — `utils/zfs.js:1667`
- `TargetCLI command: <cmd>` — every `targetcli` op (target/lun create) — `controller-zfs-generic/index.js:1064`

Timestamp-gapping those lines splits Phase A's ~6.5 s into `zfs-create` vs `zfs-set` vs `targetcli-target` vs `targetcli-lun` attribution — telling us whether the cost is in ZFS or in `targetcli`.

## Scope / safety

- Controller driver container only; sidecars and the 5-node DaemonSet unchanged (avoids log-volume on the high-frequency node ops).
- **Temporary** — a stacked PR (#REVERT) reverts this once enough CreateVolume bursts (~1 h) are captured.

## Plan

1. Merge this → Argo self-heals controller to verbose.
2. Capture ~1 h of bursts.
3. Run the Phase A per-command split against the new log lines.
4. Merge the stacked revert PR.