### PR TITLE
chore(democratic-csi): revert controller logLevel to default (info)

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -190,11 +190,6 @@ spec:
             extraArgs:
               - --http-endpoint=:8083
           driver:
-            # TEMP (perf investigation): verbose surfaces per-command zfs/targetcli
-            # timing (ZfsProcessManager/TargetCLI command lines) to split CreateVolume
-            # Phase A; node DaemonSet intentionally left at info to limit log volume.
-            # Revert via stacked PR once analysis is captured.
-            logLevel: verbose
             image:
               # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
               # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate


### PR DESCRIPTION
## What

Stacked on #311. Reverts `controller.driver.logLevel: verbose` back to the chart default (`info`). Net diff vs `main` is **zero** — the controller driver stanza returns to image-only.

## When to merge

After merging #311 and capturing ~1 h of CreateVolume bursts at `verbose` (enough `ZfsProcessManager command:` / `TargetCLI command:` lines to split Phase A). Merging this returns the controller to `info` and drops the extra log volume.

## Stacking note

Base is `chore/democratic-csi-verbose-logging` (#311). Once #311 merges to `main`, retarget this PR to `main` — its diff will then show as a clean removal of the temporary `logLevel: verbose`.