### PR TITLE
feat(pki): distribute CRL to authz

### DIFF
--- a/docs/superpowers/plans/2026-07-22-homelab-mtls-pki.md
+++ b/docs/superpowers/plans/2026-07-22-homelab-mtls-pki.md
@@ -1008,6 +1008,11 @@ The reconciler already writes the `pki-crl` Secret in `homelab-pki` (Task 7). Co
 
 - [ ] **Step 1: In `homelab-pki.yaml`, grant consumer reader SAs read on the CRL Secret**
 
+  - [x] `projectcontour`: `pki-crl-reader` ServiceAccount plus the narrowly
+    scoped `homelab-pki` Role/RoleBinding for `pki-crl`.
+  - [ ] `default`: matching reader ServiceAccount and RoleBinding (needed for
+    the HA `HTTPProxy`, outside the python-envoy-authz migration PRs).
+
 The kubernetes-provider `SecretStore` authenticates as a ServiceAccount in the *consumer* namespace; that identity needs read on `pki-crl` in `homelab-pki`. Create a reader SA per consumer namespace and bind it in `homelab-pki`:
 
 ```yaml
@@ -1068,7 +1073,7 @@ spec:
       remoteRef: { key: pki-crl, property: crl.pem, conversionStrategy: Default, decodingStrategy: None, metadataPolicy: None }
 ```
 
-- [ ] **Step 3: In `python-envoy-authz.yaml` (`projectcontour`), add the same SecretStore + ExternalSecret**
+- [x] **Step 3: In `python-envoy-authz.yaml` (`projectcontour`), add the same SecretStore + ExternalSecret**
 
 Identical to Step 2 but `namespace: projectcontour` on both the `SecretStore` and `ExternalSecret`.
 

--- a/homelab-pki.yaml
+++ b/homelab-pki.yaml
@@ -19,6 +19,12 @@ metadata:
   name: pki-reconciler
   namespace: homelab-pki
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pki-crl-reader
+  namespace: projectcontour
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -35,6 +41,17 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pki-crl-reader
+  namespace: homelab-pki
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["pki-crl"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pki-reconciler
@@ -47,6 +64,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: pki-reconciler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pki-crl-reader
+  namespace: homelab-pki
+subjects:
+  - kind: ServiceAccount
+    name: pki-crl-reader
+    namespace: projectcontour
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pki-crl-reader
 ---
 # CA cert+key delivered from Bitwarden (ha-ca-crt / ha-ca-key). Opaque, so the
 # reconciler reads /ca/tls.crt and /ca/tls.key. Never in git.

--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -18,6 +18,45 @@ spec:
       metadataPolicy: None
 ---
 apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: homelab-pki
+  namespace: projectcontour
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: homelab-pki
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: pki-crl-reader
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pki-crl
+  namespace: projectcontour
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    kind: SecretStore
+    name: homelab-pki
+  target:
+    name: pki-crl
+  data:
+  - secretKey: crl.pem
+    remoteRef:
+      key: pki-crl
+      property: crl.pem
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+---
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: frigate-x-proxy-secret


### PR DESCRIPTION
CRL is copied in-cluster and never round-tripped through Bitwarden. The reader is limited to homelab-pki/pki-crl. A stacked follow-up exposes the copied CRL to the Deployment.