### PR TITLE
feat(pki): expose CRL to authz

### DIFF
--- a/docs/superpowers/plans/2026-07-22-homelab-mtls-pki.md
+++ b/docs/superpowers/plans/2026-07-22-homelab-mtls-pki.md
@@ -1129,7 +1129,7 @@ git commit -m "feat(pki): enforce CRL at Contour HTTPProxy clientValidation"
 **Files:**
 - Modify: `python-envoy-authz.yaml`
 
-- [ ] **Step 1: Mount the CRL + env into the Deployment (mirrors `HA_CA_CERTIFICATE`)**
+- [x] **Step 1: Expose the CRL to the Deployment (mirrors `HA_CA_CERTIFICATE`)**
 
 ```yaml
         env:

--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -121,6 +121,11 @@ spec:
               secretKeyRef:
                 name: ca-ha-homelab-somemissing-info-tls
                 key: ca.crt
+          - name: HA_CRL
+            valueFrom:
+              secretKeyRef:
+                name: pki-crl
+                key: crl.pem
           # Tracing is opt-in in the app: it stays off until
           # OTEL_EXPORTER_OTLP_ENDPOINT is set. Export to the in-namespace
           # collector (application.otel-collector-contour.yaml, plaintext OTLP


### PR DESCRIPTION
Stacked on #313 so the copied pki-crl Secret exists before the Deployment reads HA_CRL. Enforcement remains dependent on the cross-repository authz source change that consumes the CRL.