### PR TITLE
fix(ci): restore renovate-deleted vikunja common subchart in vendir sync

### DIFF
--- a/.ci/vendir-sync.sh
+++ b/.ci/vendir-sync.sh
@@ -44,15 +44,22 @@ for chart_yaml in vendored/*/base/Chart.yaml; do
   helm dependency build "$chart_dir"
 done
 
-if git diff --quiet && git diff --cached --quiet; then
+# Stage before the emptiness check: `helm dependency build` rebuilds charts/
+# deps (e.g. vendored/vikunja/base/charts/common-*.tgz) that Renovate's own
+# vendir sync deleted, and those land as *untracked* files. `git diff`/`git
+# diff --cached` ignore untracked paths, so checking before staging silently
+# skipped the restore commit and the deletion reached main. Stage first, then
+# test the staged diff.
+git config user.email "woodpecker@ci"
+git config user.name "Woodpecker CI"
+git add -A vendored/ vendir.lock.yml
+
+if git diff --cached --quiet; then
   echo "vendir sync produced no file changes."
   exit 0
 fi
 
 echo "Committing vendir sync results..."
-git config user.email "woodpecker@ci"
-git config user.name "Woodpecker CI"
-git add vendored/ vendir.lock.yml
 git commit -m "chore: vendir sync
 
 Co-authored-by: Woodpecker CI <woodpecker@ci>"


### PR DESCRIPTION
## Problem

Renovate's vendir manager runs \`vendir sync\` on every vendir bump (e.g. #320, #321), which deletes \`vendored/vikunja/base/charts/common-1.5.1.tgz\` — it lives inside the vikunja git-managed path but is excluded from \`includePaths\` (upstream ships only \`Chart.lock\`, not \`charts/\`). vendir refuses to co-manage the nested \`charts/\` path, so \`vendir-sync.sh\` is meant to rebuild it via \`helm dependency build\` and commit the restore.

## Root cause

The change-detection guard ran **before** \`git add\` and used \`git diff\`/\`git diff --cached\`, which ignore untracked files. The rebuilt tarball (deleted in HEAD, recreated in the worktree) is untracked, so the guard saw "no changes," skipped the commit, and the deletion reached \`main\`. CI stayed green throughout.

## Fix

Stage \`vendored/\` first, then test \`git diff --cached\`. Verified: \`helm dependency build\` reproduces the tarball byte-for-byte, and a simulated renovate-delete → rebuild now commits the restore instead of skipping it.