### PR TITLE
fix(homelab-pki): use kubernetes_secret_v1, add .dockerignore, bump t…

### DIFF
--- a/docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md
+++ b/docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md
@@ -124,7 +124,7 @@ Both providers already download at Job runtime today (the current setup
 already does this for `hashicorp/kubernetes`), so no filesystem mirror is
 needed.
 
-The CA is read via `data "kubernetes_secret" "ca"` (in-cluster,
+The CA is read via `data "kubernetes_secret_v1" "ca"` (in-cluster,
 `hashicorp/kubernetes` provider) instead of a mounted volume — this drops the
 `/ca` volume mount and `CA_CERT`/`CA_KEY` env vars from the Job/CronJob spec
 entirely.
@@ -214,7 +214,7 @@ Devices produce, per name: `pki_private_key`, `pki_certificate` (signed by
 `pki_certificate_authority.ca`), `pki_bundle` (`format = "pkcs12"`, write-only
 password fixed to the literal string `"password"` via `password_wo` —
 preserves current behavior exactly, since that password isn't a real secret
-today either), and `kubernetes_secret` (`tls.crt`, `tls.key`, `<name>.p12`).
+today either), and `kubernetes_secret_v1` (`tls.crt`, `tls.key`, `<name>.p12`).
 
 An output exposes current serials for operators doing revocation:
 
@@ -242,7 +242,7 @@ output "device_serials" {
   No `python -m reconcile.main`, no `secrets.auto.tfvars.json` copy step.
 - **Volumes**: drop the `config` (ConfigMap) and `ca` (Secret) volume mounts
   and the `PKI_CONFIG`/`CA_CERT`/`CA_KEY` env vars — config is baked into the
-  image as `.tf`, and the CA is read via `data "kubernetes_secret"` instead
+  image as `.tf`, and the CA is read via `data "kubernetes_secret_v1"` instead
   of a mounted file. `work` emptyDir can also go (no more
   `secrets.auto.tfvars.json` intermediate file).
 - **RBAC**: unchanged — the existing `pki-reconciler` Role's secrets
@@ -268,13 +268,13 @@ human has reviewed a real plan from the real Job:
 
 1. **`tofu/imports.tf`** declares the import mechanism directly in config
    (OpenTofu 1.7+ `import` blocks), rather than running `terraform import`
-   by hand from a one-off pod. It adds `data "kubernetes_secret"
+   by hand from a one-off pod. It adds `data "kubernetes_secret_v1"
    "legacy_device"` (`for_each` over the 5 old, serial-suffixed Secret
-   names) alongside the CA's existing `data.kubernetes_secret.ca`, then:
+   names) alongside the CA's existing `data.kubernetes_secret_v1.ca`, then:
    ```hcl
    import {
      to = pki_certificate_authority.ca
-     id = "base64://${base64encode(nonsensitive(data.kubernetes_secret.ca.data["tls.crt"]))}"
+     id = "base64://${base64encode(nonsensitive(data.kubernetes_secret_v1.ca.data["tls.crt"]))}"
    }
    import {
      for_each = local.legacy_device_secrets
@@ -284,11 +284,11 @@ human has reviewed a real plan from the real Job:
    import {
      for_each = local.legacy_device_secrets
      to       = pki_certificate.device[each.key]
-     id       = "base64://${base64encode(nonsensitive(data.kubernetes_secret.legacy_device[each.key].data["tls.crt"]))}"
+     id       = "base64://${base64encode(nonsensitive(data.kubernetes_secret_v1.legacy_device[each.key].data["tls.crt"]))}"
    }
    ```
    Certificate imports use `nonsensitive(...)` around a data-source read,
-   required because the `kubernetes_secret` data source's `data`/
+   required because the `kubernetes_secret_v1` data source's `data`/
    `binary_data` attributes are schema-marked sensitive and OpenTofu's
    `import` block rejects a sensitive `id` outright ("The import id cannot
    be sensitive") — hit for real against the live Job's first plan run.
@@ -312,13 +312,22 @@ human has reviewed a real plan from the real Job:
    `file://`-based private-key import was confirmed to leave zero trace of
    the key in `tofu plan`'s output where the `base64://` form had leaked it
    in full.
+
+   Every `kubernetes_secret`/`kubernetes_secret_v1` reference in this repo's
+   `tofu/*.tf` uses `_v1`: `hashicorp/kubernetes ~> 3.0` deprecates the bare
+   name (confirmed via `tofu providers schema -json` — `_v1` is a byte-for-byte
+   identical schema, only the `deprecated` flag differs), and the bare form
+   showed up as real deprecation warnings in the live Job's plan output, 16
+   of them across every resource/data source in the config. `_v1` is the
+   only change; nothing about behavior, state, or the resources it produces
+   differs.
 2. **Ship `imports.tf` with the Job/CronJob running `tofu plan` only**
    (not `apply`) — safe to merge and let Argo sync immediately, since plan
    never mutates the cluster, regardless of whether anything has been
    imported yet. Review the plan in the Job's pod logs
    (`kubectl logs job/pki-reconcile -n homelab-pki`): expect "N to import",
    the documented one-time `private_key_pem` pending-set (gotcha #2 below),
-   and creates for the brand-new `kubernetes_secret`/`pki_bundle`/`pki_crl`
+   and creates for the brand-new `kubernetes_secret_v1`/`pki_bundle`/`pki_crl`
    resources — no unexpected reissues. If `basic_constraints`/`key_usage`
    show diffs on the imported CA/devices, fix the config to match reality
    (gotcha #1 below) and re-check the plan before proceeding.

--- a/homelab-pki.yaml
+++ b/homelab-pki.yaml
@@ -15,7 +15,7 @@
 # (kubectl logs job/pki-reconcile -n homelab-pki) without mutating anything.
 # Once that plan looks right (expect only the documented one-time
 # `private_key_pem` pending-set and creates for the brand-new
-# kubernetes_secret/pki_bundle/pki_crl resources -- no unexpected reissues),
+# kubernetes_secret_v1/pki_bundle/pki_crl resources -- no unexpected reissues),
 # a follow-up change flips both `tofu plan` lines below to
 # `tofu apply -auto-approve`, and a further change after that apply succeeds
 # once deletes tofu/imports.tf (see its header comment for why). See
@@ -25,7 +25,7 @@
 # The reconcile Job is an Argo Sync hook (runs `tofu` on each sync); the
 # CronJob re-runs periodically to keep the CRL fresh. Reconciliation is
 # idempotent. The CA private key is delivered from Bitwarden via ExternalSecret
-# and read directly by homelab-pki/tofu/ca.tf via a kubernetes_secret data
+# and read directly by homelab-pki/tofu/ca.tf via a kubernetes_secret_v1 data
 # source (no volume mount needed); cert/CRL Secrets are tofu-managed (not
 # Argo-pruned).
 ---
@@ -97,7 +97,7 @@ roleRef:
   name: pki-crl-reader
 ---
 # CA cert+key delivered from Bitwarden (ha-ca-crt / ha-ca-key). Opaque, read
-# directly by homelab-pki/tofu/ca.tf's kubernetes_secret data source. Never
+# directly by homelab-pki/tofu/ca.tf's kubernetes_secret_v1 data source. Never
 # in git.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -147,7 +147,7 @@ spec:
       serviceAccountName: pki-reconciler
       containers:
         - name: reconcile
-          image: registry.apps.nickv.me/nijave/homelab-pki:0.2.2
+          image: registry.apps.nickv.me/nijave/homelab-pki:0.2.3
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -198,7 +198,7 @@ spec:
           serviceAccountName: pki-reconciler
           containers:
             - name: reconcile
-              image: registry.apps.nickv.me/nijave/homelab-pki:0.2.2
+              image: registry.apps.nickv.me/nijave/homelab-pki:0.2.3
               imagePullPolicy: Always
               command: ["/bin/sh", "-c"]
               args:

--- a/homelab-pki/.dockerignore
+++ b/homelab-pki/.dockerignore
@@ -1,0 +1,2 @@
+tofu/.terraform/
+tofu/.terraform.lock.hcl

--- a/homelab-pki/Dockerfile
+++ b/homelab-pki/Dockerfile
@@ -19,8 +19,8 @@
 #
 # Build + push (manual, until CI step lands):
 #   cd homelab-pki
-#   docker build -t registry.apps.nickv.me/nijave/homelab-pki:0.2.2 .
-#   docker push registry.apps.nickv.me/nijave/homelab-pki:0.2.2
+#   docker build -t registry.apps.nickv.me/nijave/homelab-pki:0.2.3 .
+#   docker push registry.apps.nickv.me/nijave/homelab-pki:0.2.3
 
 FROM ghcr.io/opentofu/opentofu:1.12-minimal AS tofu
 

--- a/homelab-pki/README.md
+++ b/homelab-pki/README.md
@@ -24,7 +24,7 @@ tofu fmt -check -recursive
 ```
 
 This checks syntax/types without touching the cluster (`-backend=false`
-skips the kubernetes backend; data sources like `data.kubernetes_secret.ca`
+skips the kubernetes backend; data sources like `data.kubernetes_secret_v1.ca`
 aren't evaluated by `validate`, only by `plan`/`apply`).
 
 ## Adding or removing a device
@@ -33,7 +33,7 @@ Edit `local.users`/`local.devices` in `locals.tf`, rebuild and push the
 image (`docker build`/`push`, bump the tag), update the tag in
 `homelab-pki.yaml`. Argo picks it up on next sync; the Sync-hook Job's
 `tofu` run creates/destroys the corresponding `pki_private_key`/
-`pki_certificate`/`pki_bundle`/`kubernetes_secret` resources (once the
+`pki_certificate`/`pki_bundle`/`kubernetes_secret_v1` resources (once the
 staged cutover below has flipped the Job to `apply` -- while it's still in
 `plan` mode, this only shows up in the plan output, not the cluster).
 

--- a/homelab-pki/tofu/ca.tf
+++ b/homelab-pki/tofu/ca.tf
@@ -4,7 +4,7 @@
 # `pki-ca` Secret (never in git, never regenerated) -- see homelab-pki.yaml.
 # Imported once (see the migration procedure in the design spec); this
 # resource never re-signs the CA itself.
-data "kubernetes_secret" "ca" {
+data "kubernetes_secret_v1" "ca" {
   metadata {
     name      = "pki-ca"
     namespace = "homelab-pki"
@@ -12,7 +12,7 @@ data "kubernetes_secret" "ca" {
 }
 
 resource "pki_certificate_authority" "ca" {
-  private_key_pem = data.kubernetes_secret.ca.data["tls.key"]
+  private_key_pem = data.kubernetes_secret_v1.ca.data["tls.key"]
 
   validity      = "175320h"
   serial_number = "4d71d760878eb0a8831ce2e1d6028f61f1fc7d5f"

--- a/homelab-pki/tofu/crl.tf
+++ b/homelab-pki/tofu/crl.tf
@@ -15,7 +15,7 @@ resource "pki_crl" "ca" {
   }
 }
 
-resource "kubernetes_secret" "crl" {
+resource "kubernetes_secret_v1" "crl" {
   metadata {
     name      = "pki-crl"
     namespace = "homelab-pki"

--- a/homelab-pki/tofu/devices.tf
+++ b/homelab-pki/tofu/devices.tf
@@ -65,7 +65,7 @@ resource "pki_bundle" "device" {
   password_wo_version = 1
 }
 
-resource "kubernetes_secret" "device" {
+resource "kubernetes_secret_v1" "device" {
   for_each = local.devices
 
   metadata {

--- a/homelab-pki/tofu/imports.tf
+++ b/homelab-pki/tofu/imports.tf
@@ -8,7 +8,7 @@
 # pki_private_key / pki_certificate resource addresses, so the cutover
 # preserves them byte-identically instead of reissuing from scratch.
 #
-# Certificate imports read via a `kubernetes_secret` data source, `id` built
+# Certificate imports read via a `kubernetes_secret_v1` data source, `id` built
 # as `base64://${base64encode(nonsensitive(...))}`. `nonsensitive(...)` is
 # required (OpenTofu's `import` block rejects a sensitive `id` outright,
 # confirmed against a real in-cluster Secret), and it's safe here: a
@@ -34,7 +34,7 @@
 #      homelab-pki.yaml) -- safe to merge/deploy immediately, since plan
 #      never mutates the cluster. Review the plan in the Job's pod logs:
 #      expect "N to import", the documented one-time `private_key_pem`
-#      pending-set, and creates for the brand-new kubernetes_secret/
+#      pending-set, and creates for the brand-new kubernetes_secret_v1/
 #      pki_bundle/pki_crl resources -- no unexpected reissues.
 #   2. Once that plan looks right, flip the Job/CronJob command to
 #      `tofu apply -auto-approve`. This one apply imports the CA/devices,
@@ -51,7 +51,7 @@
 #      apply destroys -- left in place, every later plan/apply (including
 #      the CronJob's next 6-hourly run) would fail trying to read Secrets
 #      that no longer exist.
-data "kubernetes_secret" "legacy_device" {
+data "kubernetes_secret_v1" "legacy_device" {
   for_each = local.legacy_device_secrets
 
   metadata {
@@ -62,7 +62,7 @@ data "kubernetes_secret" "legacy_device" {
 
 import {
   to = pki_certificate_authority.ca
-  id = "base64://${base64encode(nonsensitive(data.kubernetes_secret.ca.data["tls.crt"]))}"
+  id = "base64://${base64encode(nonsensitive(data.kubernetes_secret_v1.ca.data["tls.crt"]))}"
 }
 
 import {
@@ -74,5 +74,5 @@ import {
 import {
   for_each = local.legacy_device_secrets
   to       = pki_certificate.device[each.key]
-  id       = "base64://${base64encode(nonsensitive(data.kubernetes_secret.legacy_device[each.key].data["tls.crt"]))}"
+  id       = "base64://${base64encode(nonsensitive(data.kubernetes_secret_v1.legacy_device[each.key].data["tls.crt"]))}"
 }


### PR DESCRIPTION
…o 0.2.3

kubernetes_secret is deprecated in hashicorp/kubernetes ~> 3.0 in favor of kubernetes_secret_v1 -- confirmed via `tofu providers schema -json` that the two are byte-for-byte identical except for the deprecated flag, so this is a pure rename. The bare name was producing 16 real deprecation warnings in the live Job's plan output, cluttering exactly the output that needs careful review during the staged cutover.

Also add homelab-pki/.dockerignore: local `tofu init` testing in homelab-pki/tofu/ leaves a .terraform/ cache and .terraform.lock.hcl behind (gitignored, but Docker's COPY doesn't respect .gitignore), and this build nearly baked a stale locally-resolved provider version into the shipped image as a result. Excluding both makes every build resolve providers fresh, matching the Job's actual runtime behavior.