### PR TITLE
homelab-pki: flip Job/CronJob to tofu apply (cutover phase 2 of 3)

### DIFF
--- a/homelab-pki.yaml
+++ b/homelab-pki.yaml
@@ -8,17 +8,22 @@
 # homelab-pki/tofu/locals.tf, no separate reconciler needed). State lives in
 # the kubernetes backend (a Secret).
 #
-# STAGED CUTOVER: both containers below run `tofu plan` only, not `apply`.
-# tofu/imports.tf declaratively imports the real CA and 5 real devices'
-# existing keys/certs into these resource addresses; running `plan` first
-# lets that import + the resulting diff be reviewed in the Job's pod logs
-# (kubectl logs job/pki-reconcile -n homelab-pki) without mutating anything.
-# Once that plan looks right (expect only the documented one-time
-# `private_key_pem` pending-set and creates for the brand-new
-# kubernetes_secret_v1/pki_bundle/pki_crl resources -- no unexpected reissues),
-# a follow-up change flips both `tofu plan` lines below to
-# `tofu apply -auto-approve`, and a further change after that apply succeeds
-# once deletes tofu/imports.tf (see its header comment for why). See
+# STAGED CUTOVER, phase 2 of 3: both containers below now run
+# `tofu apply -auto-approve`. Phase 1's `tofu plan` run (kubectl logs
+# job/pki-reconcile -n homelab-pki) showed exactly the expected diff: 11 to
+# import (the real CA + 5 real devices' keys/certs, via tofu/imports.tf,
+# byte-identical except the documented one-time private_key_pem/
+# ca_certificate_pem/ca_private_key_pem pending-sets), 12 to add (the new
+# kubernetes_secret_v1/pki_bundle/pki_crl resources), 6 to change (those
+# pending-sets), 6 to destroy (the old serial-suffixed Secrets and old CRL
+# Secret, orphaned since this config no longer declares their resource
+# addresses) -- no unexpected reissues. This one apply performs all of that
+# atomically and safely (see the design spec for why the ordering can't
+# race). Phase 3, a follow-up change to run promptly after this apply
+# succeeds once (before the CronJob's next 6-hourly run): delete
+# tofu/imports.tf, locals.tf's `legacy_device_secrets`, and the `legacy-*`
+# volumes/volumeMounts below -- their data sources/mounts reference Secrets
+# this apply destroys, so left in place they break every later run. See
 # docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md's
 # "Migration / cutover procedure" for the full rollout.
 #
@@ -128,8 +133,8 @@ spec:
         decodingStrategy: None
         metadataPolicy: None
 ---
-# Immediate reconcile: Argo Sync hook runs `tofu plan` on each sync
-# (idempotent, non-mutating -- see the staged-cutover note above).
+# Immediate reconcile: Argo Sync hook runs `tofu apply` on each sync
+# (idempotent -- see the staged-cutover note above for what this apply does).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -155,7 +160,7 @@ spec:
               set -eux
               cd /app/tofu
               tofu init -input=false -no-color
-              tofu plan -input=false -no-color
+              tofu apply -input=false -auto-approve -no-color
           resources:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: "1", memory: 512Mi }
@@ -206,7 +211,7 @@ spec:
                   set -eux
                   cd /app/tofu
                   tofu init -input=false -no-color
-                  tofu plan -input=false -no-color
+                  tofu apply -input=false -auto-approve -no-color
               resources:
                 requests: { cpu: 50m, memory: 128Mi }
                 limits: { cpu: "1", memory: 512Mi }

--- a/homelab-pki/README.md
+++ b/homelab-pki/README.md
@@ -9,9 +9,11 @@ every 6h) both run `tofu init` then one `tofu` command against this config --
 adding or removing a device is a `for_each` over `local.devices` in
 `locals.tf`, no separate reconciler step.
 
-**Staged cutover in progress:** both containers currently run `tofu plan`
-only, not `apply` -- see "One-time CA/device import" below. Once the plan
-looks right, a follow-up change flips them to `tofu apply -auto-approve`.
+**Staged cutover, phase 2 of 3 in progress:** both containers now run
+`tofu apply -auto-approve` -- phase 1's `tofu plan` run showed exactly the
+expected diff (11 to import, 12 to add, 6 to change, 6 to destroy, no
+unexpected reissues). See "One-time CA/device import" below for what this
+apply does and the required phase 3 follow-up.
 
 ## Local validation
 
@@ -63,33 +65,31 @@ rotation is security-motivated, also add the *old* serial to
 
 ## One-time CA/device import
 
-**Not yet performed against this repo's `homelab-pki` namespace.** The import
-*approach* (mechanics of bringing the existing CA and 5 devices --
-`nick-desktop`, `nick-ipad`, `nick-xps`, `pixel7`, `kara-iphone` -- under
-these resource addresses) was validated byte-identical against the real CA
-and certs in a separate harness:
-`~/Documents/workspace/go/src/github.com/nijave/terraform-provider-pki/migration/homelab-pki-import/`.
-That run proved the approach works, but it did not touch production.
-
-The actual production cutover is driven by `tofu/imports.tf` -- declarative
+The production cutover is driven by `tofu/imports.tf` -- declarative
 `import` blocks (no manual `terraform import` CLI commands, no one-off pod)
-that bind the CA and 5 devices' existing keys/certs into this config's
-resource addresses. Rollout is staged across three changes:
+that bind the real CA and 5 real devices' existing keys/certs
+(`nick-desktop`, `nick-ipad`, `nick-xps`, `pixel7`, `kara-iphone`) into this
+config's resource addresses. The import *mechanism* was validated
+byte-identical against the real CA and certs in a separate harness before
+being written into this config:
+`~/Documents/workspace/go/src/github.com/nijave/terraform-provider-pki/migration/homelab-pki-import/`.
+Rollout is staged across three changes:
 
-1. **This state:** `imports.tf` is in config, and the Job/CronJob run
-   `tofu plan` only. Safe to merge/deploy as-is -- review the plan in
-   `kubectl logs job/pki-reconcile -n homelab-pki`; expect "N to import",
-   the one-time `private_key_pem` pending-set, and creates for the new
-   `pki-<device>`/`pki-crl` Secrets, no unexpected reissues.
-2. Once that plan looks right, flip the Job/CronJob command to
-   `tofu apply -auto-approve`. One apply imports the CA/devices, destroys
-   the now-orphaned old `pki-<name>-<serial>` Secrets, and creates the new
+1. `imports.tf` shipped with the Job/CronJob running `tofu plan` only.
+   Reviewed in `kubectl logs job/pki-reconcile -n homelab-pki`: exactly the
+   expected diff (11 to import, 12 to add, 6 to change -- the documented
+   one-time pending-sets -- 6 to destroy -- the old `pki-<name>-<serial>`
+   Secrets and old CRL Secret -- no unexpected reissues). Done.
+2. **This state:** the Job/CronJob command is now `tofu apply
+   -auto-approve`. One apply imports the CA/devices, destroys the
+   now-orphaned old Secrets, and creates the new `pki-<device>`/`pki-crl`
    ones -- atomically and safely (see the design spec for why the ordering
    can't race).
-3. Immediately after that apply succeeds, delete `tofu/imports.tf` and
-   `locals.tf`'s `legacy_device_secrets` map. Their data sources read
-   Secrets that apply just destroyed -- left in place, every later
-   plan/apply (including the CronJob's next run) fails.
+3. **Required follow-up, promptly after this apply succeeds once** (before
+   the CronJob's next 6-hourly run): delete `tofu/imports.tf`,
+   `locals.tf`'s `legacy_device_secrets` map, and the `legacy-*`
+   volumes/volumeMounts in `homelab-pki.yaml`. They reference Secrets this
+   apply destroys -- left in place, every later plan/apply fails.
 
 Full detail in the "Migration / cutover procedure" section of
 `docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md`.


### PR DESCRIPTION
## Summary

Phase 2 of the staged homelab-pki cutover (#333, #335 merged phase 1: `tofu plan` + declarative import blocks).

Phase 1's plan run (pod `pki-reconcile-plzr9`, image `0.2.3`) showed exactly the expected diff and nothing else:
- **11 to import** — the real CA + 5 real devices' keys/certs (`nick-desktop`, `nick-ipad`, `nick-xps`, `pixel7`, `kara-iphone`), byte-identical except the documented one-time `private_key_pem`/`ca_certificate_pem`/`ca_private_key_pem` pending-sets
- **12 to add** — the new `kubernetes_secret_v1`/`pki_bundle`/`pki_crl` resources
- **6 to change** — those pending-sets
- **6 to destroy** — the old serial-suffixed Secrets (`pki-<name>-<serial>`) and old CRL Secret, already orphaned since this config doesn't declare their resource addresses
- No unexpected reissues, no errors, no warnings

This PR flips both the Job and CronJob from `tofu plan` to `tofu apply -auto-approve`. One apply performs the import/destroy/create atomically and safely: `tofu apply` (run without a saved plan) computes its whole plan — including every data source and import-target read — before executing any create/update/destroy, so reading the old Secrets' data for import always happens-before their destroy in the same apply.

## Required follow-up (phase 3, not in this PR)

Promptly after this apply succeeds once — before the CronJob's next 6-hourly run — a follow-up PR must delete `tofu/imports.tf`, `locals.tf`'s `legacy_device_secrets` map, and the `legacy-*` volumes/volumeMounts in `homelab-pki.yaml`. They reference Secrets this apply destroys, so left in place every later plan/apply fails.

## Test plan

- [x] `sh .ci/validate.sh` — all manifests valid
- [x] Reviewed the real phase-1 plan output in full (pod `pki-reconcile-plzr9`) before proceeding — confirmed byte-identical CA/device import, correct serial preservation via `device_serials` output, private keys never appear in logs (only `file://` paths)
- [ ] Watch the Sync-hook Job's apply output after this merges; confirm it completes successfully, then open the phase-3 cleanup PR