### PR TITLE
homelab-pki: clean up migration-history comments and docs

### DIFF
--- a/homelab-pki.yaml
+++ b/homelab-pki.yaml
@@ -3,27 +3,14 @@
 # A single image (registry.apps.nickv.me/nijave/homelab-pki) bundles OpenTofu
 # + the tofu/ config: pki_certificate_authority/pki_certificate/pki_crl/etc.
 # (nijave/pki provider) express the CA import, per-device issuance, and CRL
-# generation declaratively -- one `tofu` invocation reconciles everything
-# (adding/removing a device is a for_each over the device map in
-# homelab-pki/tofu/locals.tf, no separate reconciler needed). State lives in
-# the kubernetes backend (a Secret).
+# generation declaratively -- one `tofu apply` reconciles everything. Adding
+# or removing a device is a for_each over the device map in
+# homelab-pki/tofu/locals.tf; no separate reconciler. State lives in the
+# kubernetes backend (a Secret).
 #
-# STAGED CUTOVER: complete. The real CA and 5 real devices (nick-desktop,
-# nick-ipad, nick-xps, pixel7, kara-iphone) were imported byte-identically
-# via tofu/imports.tf (11 imported, 12 added, 6 changed, 6 destroyed --
-# confirmed via `kubectl logs job/pki-reconcile` and `openssl verify`
-# against the new pki-<device> Secrets). imports.tf, locals.tf's
-# `legacy_device_secrets`, and the `legacy-*` volumes/volumeMounts that only
-# existed for that one-time import are now removed. See
-# docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md's
-# "Migration / cutover procedure" for the full rollout this completed.
-#
-# The reconcile Job is an Argo Sync hook (runs `tofu` on each sync); the
-# CronJob re-runs periodically to keep the CRL fresh. Reconciliation is
-# idempotent. The CA private key is delivered from Bitwarden via ExternalSecret
-# and read directly by homelab-pki/tofu/ca.tf via a kubernetes_secret_v1 data
-# source (no volume mount needed); cert/CRL Secrets are tofu-managed (not
-# Argo-pruned).
+# The reconcile Job is an Argo Sync hook (runs on each sync); the CronJob
+# re-runs every 6h to keep the CRL fresh. The CA private key is delivered
+# from Bitwarden via ExternalSecret and read by homelab-pki/tofu/ca.tf.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -124,8 +111,6 @@ spec:
         decodingStrategy: None
         metadataPolicy: None
 ---
-# Immediate reconcile: Argo Sync hook runs `tofu apply` on each sync
-# (idempotent).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -143,7 +128,7 @@ spec:
       serviceAccountName: pki-reconciler
       containers:
         - name: reconcile
-          image: registry.apps.nickv.me/nijave/homelab-pki:0.2.4
+          image: registry.apps.nickv.me/nijave/homelab-pki:0.2.5
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           args:
@@ -156,9 +141,8 @@ spec:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: "1", memory: 512Mi }
 ---
-# Periodic re-run to keep the CRL fresh (regenerate before nextUpdate) and
-# correct any drift. concurrencyPolicy Forbid; the OpenTofu state lock also
-# guards against overlap with the Sync-hook Job.
+# concurrencyPolicy Forbid; the OpenTofu state lock also guards against
+# overlap with the Sync-hook Job.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -179,7 +163,7 @@ spec:
           serviceAccountName: pki-reconciler
           containers:
             - name: reconcile
-              image: registry.apps.nickv.me/nijave/homelab-pki:0.2.4
+              image: registry.apps.nickv.me/nijave/homelab-pki:0.2.5
               imagePullPolicy: Always
               command: ["/bin/sh", "-c"]
               args:

--- a/homelab-pki/Dockerfile
+++ b/homelab-pki/Dockerfile
@@ -1,11 +1,5 @@
-# homelab-pki/Dockerfile
-#
-# Image bundles OpenTofu + the tofu/ config (pki_* resources from the
-# nijave/pki provider express CA import, per-device issuance, and CRL
-# generation declaratively). Entry point is /bin/sh; the Job/CronJob run
-# sequence is:
-#   tofu -chdir=/app/tofu init
-#   tofu -chdir=/app/tofu apply -auto-approve
+# Bundles OpenTofu + the tofu/ config; entrypoint is /bin/sh (homelab-pki.yaml
+# runs `tofu init && tofu apply` in the Job/CronJob).
 #
 # NOTE on base image: `ghcr.io/opentofu/opentofu:1.12` (the full image)
 # cannot be used as a Dockerfile FROM base -- as of OpenTofu 1.10 it ships an
@@ -19,8 +13,8 @@
 #
 # Build + push (manual, until CI step lands):
 #   cd homelab-pki
-#   docker build -t registry.apps.nickv.me/nijave/homelab-pki:0.2.4 .
-#   docker push registry.apps.nickv.me/nijave/homelab-pki:0.2.4
+#   docker build -t registry.apps.nickv.me/nijave/homelab-pki:0.2.5 .
+#   docker push registry.apps.nickv.me/nijave/homelab-pki:0.2.5
 
 FROM ghcr.io/opentofu/opentofu:1.12-minimal AS tofu
 

--- a/homelab-pki/README.md
+++ b/homelab-pki/README.md
@@ -5,12 +5,9 @@ desired state: CA import (`ca.tf`), per-device key/cert/PKCS12 issuance
 (`devices.tf`, `locals.tf`), and CRL generation (`crl.tf`), all using the
 [`nijave/pki`](https://registry.terraform.io/providers/nijave/pki) provider.
 `homelab-pki.yaml`'s Job (Argo Sync hook) and CronJob (`pki-crl-refresh`,
-every 6h) both run `tofu init` then one `tofu` command against this config --
-adding or removing a device is a `for_each` over `local.devices` in
-`locals.tf`, no separate reconciler step.
-
-Both containers run `tofu apply -auto-approve`. The one-time cutover onto
-this provider is complete -- see "One-time CA/device import" below.
+every 6h) both run `tofu init && tofu apply` against this config -- adding
+or removing a device is a `for_each` over `local.devices` in `locals.tf`,
+no separate reconciler step.
 
 ## Local validation
 
@@ -31,10 +28,8 @@ aren't evaluated by `validate`, only by `plan`/`apply`).
 Edit `local.users`/`local.devices` in `locals.tf`, rebuild and push the
 image (`docker build`/`push`, bump the tag), update the tag in
 `homelab-pki.yaml`. Argo picks it up on next sync; the Sync-hook Job's
-`tofu` run creates/destroys the corresponding `pki_private_key`/
-`pki_certificate`/`pki_bundle`/`kubernetes_secret_v1` resources (once the
-staged cutover below has flipped the Job to `apply` -- while it's still in
-`plan` mode, this only shows up in the plan output, not the cluster).
+`tofu apply` creates/destroys the corresponding `pki_private_key`/
+`pki_certificate`/`pki_bundle`/`kubernetes_secret_v1` resources.
 
 ## Revoking a device (lost/sold)
 
@@ -59,22 +54,3 @@ provider-assigned serial), new `pki_bundle` content, and an in-place update
 of the same `pki-<name>` Secret (same name -- no orphaned old Secret). If the
 rotation is security-motivated, also add the *old* serial to
 `revoked_serials` per the revocation steps above.
-
-## One-time CA/device import (complete)
-
-The production cutover onto this provider is done. The real CA and 5 real
-devices (`nick-desktop`, `nick-ipad`, `nick-xps`, `pixel7`, `kara-iphone`)
-were imported byte-identically via a now-removed `tofu/imports.tf`
-(declarative `import` blocks, no manual `terraform import` CLI commands, no
-one-off pod) -- `Apply complete! Resources: 11 imported, 12 added, 6
-changed, 6 destroyed.` -- confirmed against the live cluster with `openssl
-verify` (a real device cert validates against the real CA, serial preserved
-exactly). The import *mechanism* was validated in a separate harness before
-being written into this config:
-`~/Documents/workspace/go/src/github.com/nijave/terraform-provider-pki/migration/homelab-pki-import/`.
-
-Full detail (the staged rollout, the two import gotchas, why the old
-Secrets could be destroyed safely in the same apply) is in the "Migration /
-cutover procedure" section of
-`docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md`,
-kept as a record of what happened.

--- a/homelab-pki/tofu/ca.tf
+++ b/homelab-pki/tofu/ca.tf
@@ -1,9 +1,6 @@
-# homelab-pki/tofu/ca.tf
-#
 # The CA cert+key are delivered from Bitwarden via ExternalSecret into the
-# `pki-ca` Secret (never in git, never regenerated) -- see homelab-pki.yaml.
-# Imported once (see the migration procedure in the design spec); this
-# resource never re-signs the CA itself.
+# `pki-ca` Secret (never in git) -- see homelab-pki.yaml. This resource
+# never regenerates or re-signs the CA.
 data "kubernetes_secret_v1" "ca" {
   metadata {
     name      = "pki-ca"
@@ -28,10 +25,10 @@ resource "pki_certificate_authority" "ca" {
     }
   }
 
-  # Declared explicitly even though they equal this resource's own defaults:
-  # ImportState always populates these blocks from the real certificate's
-  # extensions, so an omitted block plans as null -- a block-shape mismatch,
-  # not a no-op -- and would force a reissue with a fresh not_before.
+  # Declared explicitly, not omitted, even though they equal this
+  # resource's schema defaults: an omitted block is null, and re-importing
+  # this CA after a state loss would then plan as a mismatch -- not a
+  # no-op -- forcing a reissue with a fresh not_before.
   basic_constraints {
     ca       = true
     critical = true

--- a/homelab-pki/tofu/crl.tf
+++ b/homelab-pki/tofu/crl.tf
@@ -1,4 +1,3 @@
-# homelab-pki/tofu/crl.tf
 resource "pki_crl" "ca" {
   ca_certificate_pem = pki_certificate_authority.ca.certificate_pem
   ca_private_key_pem = pki_certificate_authority.ca.private_key_pem

--- a/homelab-pki/tofu/devices.tf
+++ b/homelab-pki/tofu/devices.tf
@@ -1,4 +1,3 @@
-# homelab-pki/tofu/devices.tf
 resource "pki_private_key" "device" {
   for_each = local.devices
 
@@ -33,9 +32,8 @@ resource "pki_certificate" "device" {
     ))
   }
 
-  # Declared explicitly -- see the comment on pki_certificate_authority.ca in
-  # ca.tf for why (applies to every imported device cert; harmless for new
-  # ones created fresh, since a create has no prior state to mismatch).
+  # Declared explicitly, not omitted -- see ca.tf's pki_certificate_authority.ca
+  # comment for why.
   basic_constraints {
     ca       = false
     critical = true
@@ -59,8 +57,8 @@ resource "pki_bundle" "device" {
   chain_pem       = [pki_certificate_authority.ca.certificate_pem]
   friendly_name   = each.key
 
-  # Write-only: preserves the current (non-secret) hardcoded password
-  # exactly -- never stored in state.
+  # Write-only, never stored in state. Plain literal is fine: all devices
+  # share this password and it isn't a real secret.
   password_wo         = "password"
   password_wo_version = 1
 }

--- a/homelab-pki/tofu/locals.tf
+++ b/homelab-pki/tofu/locals.tf
@@ -1,7 +1,3 @@
-# homelab-pki/tofu/locals.tf
-#
-# Devices/identities are native Terraform data, not a separate config.hcl +
-# ConfigMap (that required hand-syncing two copies of the same data).
 # Adding or removing a device means editing this file and rebuilding the
 # image (see homelab-pki/README.md).
 
@@ -50,11 +46,11 @@ locals {
   ]...)
 
   device_domain   = "ha.apps.somemissing.info"
-  device_validity = "175320h" # 20 years, matching the existing certificates
+  device_validity = "175320h" # 20 years
 
-  # Ordered DN attribute list per device (commonName, uid, displayName,
-  # givenName, surname, organization, then any organizationalUnits) --
-  # order matters for byte-identical import; skips unset optional fields.
+  # Ordered DN attribute list per device: fixed order (commonName, uid,
+  # displayName, givenName, surname, organization, then any
+  # organizationalUnits), skipping unset optional fields.
   device_attributes = {
     for name, d in local.devices : name => concat(
       [{ oid = "commonName", value = lookup(d, "common_name", "${name}.${local.device_domain}") }],

--- a/homelab-pki/tofu/main.tf
+++ b/homelab-pki/tofu/main.tf
@@ -1,4 +1,3 @@
-# homelab-pki/tofu/main.tf
 terraform {
   required_version = ">= 1.11.0"
 


### PR DESCRIPTION
## Summary

No functional changes -- comments/docs only, plus an image rebuild since `.tf` comment changes are baked into it via `COPY tofu/`.

The cutover onto `terraform-provider-pki` is complete and its full history is already recorded in `docs/superpowers/specs/2026-08-01-homelab-pki-provider-migration-design.md`. This trims the live operational files down to what's needed to understand/maintain the current system, not what it took to get here:

- `homelab-pki.yaml`: dropped the "STAGED CUTOVER" narration block and per-resource comments that just repeated the file header (e.g. "Immediate reconcile: Argo Sync hook runs `tofu apply`..." right above a Job whose header already said that).
- `homelab-pki/README.md`: dropped the "One-time CA/device import" section entirely -- pure migration history with no ongoing operational value, already preserved in the design spec.
- `tofu/*.tf`: dropped the repeated `# homelab-pki/tofu/<filename>` header comment on every file (redundant with the actual filename), and reworded a few comments that referenced the since-removed `imports.tf`/old `config.hcl` instead of describing current behavior (e.g. `device_validity`'s "matching the existing certificates" comparison to a system that no longer exists).

Kept every comment that explains non-obvious rationale still relevant to the live system: the two `basic_constraints`/`key_usage` "declare explicitly, don't omit" gotchas (still real -- they'd bite on any future re-import), the CRD-defaults-spelled-out gotcha on the ExternalSecret, why `for_each` keys on device name not serial, etc.

Image bumped to `0.2.5` (built `--no-cache`, smoke-tested: resolves providers fresh, valid config).

## Test plan

- [x] `sh .ci/validate.sh` — all manifests valid
- [x] `tofu init -backend=false && tofu validate && tofu fmt -check -recursive` — valid, formatted
- [x] Docker image `0.2.5` built `--no-cache` and smoke-tested before push