### PR TITLE
fix(renovate): disable helm-values/helmv3 for vendored/bjw-s-common

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,9 +48,9 @@
   ],
   "packageRules": [
     {
-      "description": "vikunja: the image is tracked by the custom regex manager (the mirror registry+tag pattern) and the chart by the vendir manager (git ref in vendir.yml). Disable the auto helm managers on the Application valuesObject and the vendored chart — helm-values otherwise concatenates the image registry+repository into a malformed dep, and helm-values/helmv3 would raise spurious PRs editing vendir-managed Chart.yaml/values.yaml.",
+      "description": "vikunja: the image is tracked by the custom regex manager (the mirror registry+tag pattern) and the charts by the vendir manager (git ref / helmChart version in vendir.yml). Disable the auto helm managers on the Application valuesObject and the vendored charts — helm-values otherwise concatenates the image registry+repository into a malformed dep, and helm-values/helmv3 would raise spurious PRs editing vendir-managed Chart.yaml/values.yaml. vendored/bjw-s-common is the common subchart vendored as its own sibling directory (see vendir.yml) — without it here, helm-values scans its default values.yaml directly and opens PRs bumping unused addon image tags (gluetun, code-server, ...) that vendir just overwrites on the next sync.",
       "matchManagers": ["helm-values", "helmv3"],
-      "matchFileNames": ["application.vikunja.yaml", "vendored/vikunja/**"],
+      "matchFileNames": ["application.vikunja.yaml", "vendored/vikunja/**", "vendored/bjw-s-common/**"],
       "enabled": false
     },
     {


### PR DESCRIPTION
## Summary
- `a9bb014` (#339) vendored the vikunja common subchart into its own sibling directory, `vendored/bjw-s-common/base`, instead of a `.tgz` nested under `vendored/vikunja/`.
- The existing `renovate.json` packageRule that disables the `helm-values`/`helmv3` managers for vikunja's vendir-managed files only matches `application.vikunja.yaml` and `vendored/vikunja/**`, so it no longer covers the new sibling path.
- Renovate now scans `vendored/bjw-s-common/base/values.yaml` directly and opens spurious PRs bumping default addon image tags baked into the common chart (#340 gluetun, #341 code-server) — addons vikunja doesn't even enable, in a file vendir fully regenerates on every sync anyway.
- Extends `matchFileNames` to also include `vendored/bjw-s-common/**`, matching the existing `vendored/vikunja/**` pattern.

## Test plan
- [x] `python3 -m json.tool renovate.json` confirms valid JSON.
- [ ] After merge, close #340 and #341 and confirm Renovate does not reopen them on the next run.