### PR TITLE
chore(renovate): pin vikunja's bjw-s common chart at 1.5.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,10 +78,11 @@
       "groupName": "external-secrets-crds"
     },
     {
-      "description": "vikunja's bjw-s common subchart — vendored via vendir's helmChart fetch into vendored/bjw-s-common/base (a plain symlink at vendored/vikunja/base/charts/common points there; see vendir.yml). NOTE: the version must satisfy what go-vikunja/helm-chart's Chart.lock expects; this bumps independently of the vikunja git ref (also vendir-managed) and can drift — review together.",
+      "description": "vikunja's bjw-s common subchart — vendored via vendir's helmChart fetch into vendored/bjw-s-common/base (a plain symlink at vendored/vikunja/base/charts/common points there; see vendir.yml). Pinned at 1.5.1: go-vikunja/helm-chart (latest tag v2.0.2) still assumes bjw-s-common's pre-2.0 single `controller:` schema, while common >=2.0 replaced it with a `controllers:` map — `helm template` against 5.0.1 fails outright with \"No enabled controller found with identifier 'main'\". Re-enable once go-vikunja/helm-chart ships a release compatible with the newer common schema.",
       "matchManagers": ["vendir"],
       "matchPackageNames": ["common"],
-      "groupName": "vikunja-common-chart"
+      "groupName": "vikunja-common-chart",
+      "enabled": false
     },
     {
       "description": "Contour — vendored whole-release via vendir; envoy image is tracked separately via kubernetes manager on the overlay patch",


### PR DESCRIPTION
## Summary
- Disables Renovate's `vendir` updates for the `common` package used by vikunja's vendored bjw-s common chart, pinning it at 1.5.1.
- go-vikunja/helm-chart (latest tag `v2.0.2`) still targets bjw-s-common's pre-2.0 single `controller:` schema. common `>=2.0` replaced it with a `controllers:` map, which is a breaking, non-additive change.
- Verified by rendering `vendored/vikunja/base` with `helm template` (the same call CI's `validate-helm` step and ArgoCD make) against #344's bumped chart (5.0.1): it fails outright with `Service 'main': No enabled controller found with identifier 'main'. Available controllers: []`. Rendering against the current pinned 1.5.1 on `main` succeeds.
- `git ls-remote` confirms `v2.0.2` is still go-vikunja/helm-chart's newest tag, so there's no newer upstream release that already supports the common v2+ schema — this needs to stay pinned until one ships.
- Note: CI's `validate-helm` step didn't catch this on #344 because it's gated to `path: application.*.yaml`, and that PR only touched `vendored/**`/`vendir.*`, so the render check never ran there.

## Test plan
- [x] `python3 -c "import json; json.load(open('renovate.json'))"` — valid JSON
- [x] Confirmed pre-existing (unrelated) `renovate-config-validator` errors are unchanged from `main` — this edit adds no new validation errors
- [ ] Renovate should stop proposing updates for this dependency on its next run