### PR TITLE
fix(democratic-csi): bump image to 60bb969 to fix double-quoting outage

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -198,8 +198,10 @@ spec:
             image:
               # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
               # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate
+              # 60bb969: fixes targetCliCommand/pcsCommand/nvmetCliCommand/spdkCliCommand
+              # double-quoting regression from b39038e (broke all CreateVolume/DeleteVolume)
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 4c4d999
+              tag: 60bb969
         node:
           cleanup:
             image:
@@ -210,8 +212,10 @@ spec:
             image:
               # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
               # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate
+              # 60bb969: fixes targetCliCommand/pcsCommand/nvmetCliCommand/spdkCliCommand
+              # double-quoting regression from b39038e (broke all CreateVolume/DeleteVolume)
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 4c4d999
+              tag: 60bb969
         csiProxy:
           image:
             # renovate: datasource=docker depName=democraticcsi/csi-grpc-proxy


### PR DESCRIPTION
## What

Bumps the democratic-csi controller/node driver image from \`4c4d999\` to
\`60bb969\`, which includes [nijave/democratic-csi#18](https://github.com/nijave/democratic-csi/pull/18).

## Why

\`4c4d999\` (deployed today) broke **every** CreateVolume/DeleteVolume call
for the zfs-generic-iscsi driver's targetcli strategy. A security-hardening
commit merged into the fork's master (\`b39038e\`, escaping SSH exec args)
made \`execClient.buildCommand()\` shell-escape each arg by wrapping it in
single quotes - colliding with \`targetCliCommand\`/\`pcsCommand\`/
\`nvmetCliCommand\`/\`spdkCliCommand\`'s own pre-existing manual single-quote
wrap. The generated command ends up double-single-quoted, which the
remote shell collapses into one unexecutable "word":

\`\`\`
sh: 8: echo "# delete target
cd /iscsi
delete iqn...
...
exit" | sudo targetcli: not found
\`\`\`
(exit code 127)

Confirmed via HyperDX: 3 volumes (\`pvc-6e8aad45...\`, \`pvc-a4ade1ef...\`,
\`pvc-09d614c3...\`) failing DeleteVolume on every retry since 01:33:33 UTC.
Reproduced the exact broken command directly against the NAS and confirmed
the fix resolves it.

## Test plan

- [x] Reproduced the regression's exact command construction against the NAS, confirmed it fails identically to production (exit 127)
- [x] Verified the fixed command construction (in 60bb969) executes correctly against the NAS, both with plain \`targetcli\` and via \`targetclid\` daemon mode
- [x] Built and pushed \`registry.apps.nickv.me/democratic-csi/democratic-csi:60bb969\`
- [ ] Confirm the 3 stuck PVCs' DeleteVolume succeeds after rollout
- [ ] Confirm a fresh CreateVolume succeeds after rollout