### PR TITLE
fix(democratic-csi): bump image to 79ea557, removes redundant targetCliMutex

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -198,10 +198,10 @@ spec:
             image:
               # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
               # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate
-              # 60bb969: fixes targetCliCommand/pcsCommand/nvmetCliCommand/spdkCliCommand
-              # double-quoting regression from b39038e (broke all CreateVolume/DeleteVolume)
+              # 79ea557: removes redundant targetCliMutex client-side serialization
+              # (targetcli already serializes itself via its own NAS-side flock)
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 60bb969
+              tag: 79ea557
         node:
           cleanup:
             image:
@@ -212,10 +212,10 @@ spec:
             image:
               # custom build with zfs.deleteVolumeIgnoreForeignSnapshots
               # (feat/delete-volume-ignore-foreign-snapshots), not managed by renovate
-              # 60bb969: fixes targetCliCommand/pcsCommand/nvmetCliCommand/spdkCliCommand
-              # double-quoting regression from b39038e (broke all CreateVolume/DeleteVolume)
+              # 79ea557: removes redundant targetCliMutex client-side serialization
+              # (targetcli already serializes itself via its own NAS-side flock)
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 60bb969
+              tag: 79ea557
         csiProxy:
           image:
             # renovate: datasource=docker depName=democraticcsi/csi-grpc-proxy


### PR DESCRIPTION
## What

Bumps the democratic-csi controller/node driver image from \`60bb969\` to
\`79ea557\`, which includes [nijave/democratic-csi#19](https://github.com/nijave/democratic-csi/pull/19).

## Why

\`targetCliCommand()\` wrapped every \`targetcli\` invocation in an in-process
JS \`Mutex\` (\`targetCliMutex\`), serializing all calls to one-at-a-time per
controller pod, client-side. This was redundant: \`targetcli-fb\` already
takes an exclusive \`flock()\` on \`/var/run/targetcli.lock\` for its entire
session, serializing every invocation NAS-wide regardless of caller.

Observed in production: under a 10-deep concurrent burst (CI-driven PVC
churn), the last-served volume waited ~9.5s, purely from this client-side
queueing on top of the NAS-side lock. #19 removes it — see that PR for the
full git-blame investigation tracing the mutex's origin to an unrelated
\`nvmetcli\` bug fix (copy-pasted to the sibling \`targetcli\` function with
no targetcli-specific justification).

## Test plan

- [x] \`node --check\` on the modified file (done in #19)
- [x] Confirmed the generated \`targetcli\` command shape is unchanged
- [x] Built and pushed \`registry.apps.nickv.me/democratic-csi/democratic-csi:79ea557\`
- [ ] Re-measure concurrent-burst tail latency post-rollout to confirm the improvement
- [ ] Confirm no regressions in real Create/DeleteVolume traffic post-rollout