### PR TITLE
feat(democratic-csi): manage iSCSI session timeouts via node-db

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -15,6 +15,10 @@ spec:
         node-db.node.session.auth.authmethod: CHAP
         node-db.node.session.auth.username: k8s
         node-db.node.session.auth.password: "{{ .password }}"
+        node-db.node.session.timeo.replacement_timeout: "30"
+        "node-db.node.conn[0].timeo.login_timeout": "5"
+        "node-db.node.conn[0].timeo.noop_out_interval": "2"
+        "node-db.node.conn[0].timeo.noop_out_timeout": "2"
   data:
   - secretKey: password
     remoteRef:


### PR DESCRIPTION
## What

Add four iSCSI timeout keys to the democratic-csi node-stage secret
(`node-stage-secret-zfs-generic-iscsi-csi-democratic-csi`) so per-volume
iSCSI session/connection timeouts are managed by the driver:

```
node-db.node.session.timeo.replacement_timeout: "30"
node-db.node.conn[0].timeo.login_timeout: "5"
node-db.node.conn[0].timeo.noop_out_interval: "2"
node-db.node.conn[0].timeo.noop_out_timeout: "2"
```

## Why

The stock iSCSI defaults (replacement_timeout=120s, login_timeout=15s,
noop 5s/5s) are tuned for lossy/remote fabrics. On this cluster's <1ms
local L2 network they are far too conservative: stale or failed sessions
linger long enough to jam the node's serialized host `iscsid`. A real
incident saw one node reach 201 sessions / 195 dead devices with a stuck
`iscsiadm`.

democratic-csi applies any node-stage CSI secret key prefixed `node-db.`
to the per-target node record via `iscsiadm -m node -o update` at
NodeStageVolume time (see `createNodeDBEntry` in `src/utils/iscsi.js` and
`src/driver/index.js`). This overrides the `iscsid.conf` defaults per
record, so timeouts can be managed in-driver without editing any host
`iscsid.conf`. The node-stage secret already uses this exact mechanism
for CHAP auth.

## Tradeoff to review

`replacement_timeout: "30"` is the deliberate/tunable knob. This cluster
has a **single portal and no multipath**, so replacement_timeout is how
long an RWO volume rides through a target blip before I/O errors surface.
It must stay **>= the TrueNAS target's restart time**. 30s is a
conservative 4x improvement over the 120s default -- bump it if target
restarts run longer. The other three (login/noop) are low-risk to
tighten.

## Scope

- Only touches the node-stage secret's `template.data`; the driver-config
  ExternalSecret and everything else in the file are untouched.
- **Forward-only**: applies to node records created at stage time going
  forward, not retroactively to existing leaked sessions.