### PR TITLE
fix(democratic-csi): drop invalid node.conn[0] secret keys

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -15,10 +15,10 @@ spec:
         node-db.node.session.auth.authmethod: CHAP
         node-db.node.session.auth.username: k8s
         node-db.node.session.auth.password: "{{ .password }}"
+        # node.conn[0].timeo.* (login/noop tightening) cannot go here: Secret
+        # data keys must match [-._a-zA-Z0-9]+ so brackets are rejected by the
+        # API server; set those via host iscsid.conf if needed
         node-db.node.session.timeo.replacement_timeout: "30"
-        "node-db.node.conn[0].timeo.login_timeout": "5"
-        "node-db.node.conn[0].timeo.noop_out_interval": "2"
-        "node-db.node.conn[0].timeo.noop_out_timeout": "2"
   data:
   - secretKey: password
     remoteRef:


### PR DESCRIPTION
## Summary
The ExternalSecret `node-stage-secret-zfs-generic-iscsi-csi-democratic-csi` has been stuck in `SecretSyncedError` since 95f97dd landed this morning. The API server rejects the secret update because Secret data keys must match `[-._a-zA-Z0-9]+` — the three `node-db.node.conn[0].timeo.*` keys contain brackets, which can never be valid. Because the update is rejected atomically, even the valid `replacement_timeout` key never reached the live secret.

## Fix
- Remove the three bracket keys (verified against democratic-csi source: it only reads `node-db.`-prefixed secret keys verbatim into `iscsiadm`, so there is no bracket-free encoding — these settings cannot be delivered via the node-stage secret at all).
- Keep `node-db.node.session.timeo.replacement_timeout: "30"` — the deliberate knob from 95f97dd, and a valid key.
- Comment documents why conn[0] settings can't live here (host `iscsid.conf` is the alternative if login/noop tightening is still wanted).

## Verification
- Server-side dry-run of a Secret with the remaining four keys passes API validation.
- A direct `kubectl apply` of the fixed ExternalSecret was reverted by Argo self-heal within seconds, confirming the fix must land in git.