### PR TITLE
feat: iscsi-host-config daemonset pins iscsid.conf conn[0] timeouts

### DIFF
--- a/iscsi-host-config.yaml
+++ b/iscsi-host-config.yaml
@@ -1,4 +1,4 @@
-# DaemonSet: per-node iSCSI storage timeout tuning. Two duties:
+# DaemonSet iscsi-host-config: per-node iSCSI storage tuning. Two duties:
 # lower the SCSI command timeout for iSCSI-backed disks, and pin
 # node.conn[0].timeo.* defaults in each host's /etc/iscsi/iscsid.conf.
 #
@@ -13,14 +13,14 @@
 #
 # Why (iscsid.conf pinning): the node.conn[0].timeo.* settings cannot ride the
 # democratic-csi node-stage secret -- Kubernetes Secret data keys must match
-# [-._a-zA-Z0-9]+, so bracket keys are rejected by the API server. democratic-csi
-# creates each iSCSI node record fresh at NodeStageVolume time and
-# `iscsiadm -o new` copies defaults from iscsid.conf, so values pinned here
-# reach every volume staged after the change -- forward-only, the same
-# semantics the node-db.* secret keys would have had. node-db.* secret keys
-# (CHAP auth, replacement_timeout) override these defaults per record, so
-# there is no overlap: bracket keys live here, bracket-free keys live on the
-# node-stage secret.
+# [-._a-zA-Z0-9]+, so bracket keys are rejected by the API server. Pinned once
+# at container startup (re-applied on pod restart), not in the periodic sweep:
+# the values only matter when node records are created, and the working
+# assumption is that a node reboot after the first apply is what brings the
+# node fully onto the new settings. node-db.* secret keys (CHAP auth,
+# replacement_timeout) override these defaults per record, so there is no
+# overlap: bracket keys live here, bracket-free keys live on the node-stage
+# secret.
 #
 # iSCSI discrimination: iSCSI disks are identified solely by a by-path id
 # containing "-iscsi-" (e.g. /dev/disk/by-path/ip-172.16.1.118:3260-iscsi-iqn...
@@ -39,18 +39,18 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: scsi-timeout
+  name: iscsi-host-config
   namespace: kube-system
   labels:
-    app: scsi-timeout
+    app: iscsi-host-config
 spec:
   selector:
     matchLabels:
-      app: scsi-timeout
+      app: iscsi-host-config
   template:
     metadata:
       labels:
-        app: scsi-timeout
+        app: iscsi-host-config
     spec:
       # Run on every node, including control-plane / otherwise-tainted nodes.
       tolerations:
@@ -58,7 +58,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-        - name: scsi-timeout
+        - name: iscsi-host-config
           image: registry.apps.nickv.me/library/busybox:1.38.0
           # TIMEOUT: SCSI command timeout (seconds) to apply to iSCSI disks.
           # INTERVAL: how often to re-sweep, so disks that attach later are
@@ -68,7 +68,7 @@ spec:
               value: "10"
             - name: INTERVAL
               value: "60"
-            # iscsid.conf defaults pinned on each host (see header comment).
+            # iscsid.conf defaults pinned once at startup (see header comment).
             # Stock open-iscsi defaults are 15/5/5, tuned for lossy fabrics;
             # tightened for this <1ms local L2.
             - name: ISCSI_LOGIN_TIMEOUT
@@ -81,7 +81,6 @@ spec:
           args:
             - |
               set -eu
-              echo "scsi-timeout: applying SCSI cmd timeout=${TIMEOUT}s to iSCSI disks and pinning iscsid.conf conn[0] timeouts every ${INTERVAL}s"
               CONF=/etc/iscsi/iscsid.conf
               # Pin an iscsid.conf default: replace an active line whose value
               # differs, append when the key is absent or only commented out.
@@ -98,14 +97,18 @@ spec:
                   echo "$(date -Iseconds) $CONF: $key ${cur} -> ${val}"
                 fi
               }
+              # One-shot at startup; assumed to fully take effect after the
+              # node's next reboot (see header comment).
+              echo "iscsi-host-config: pinning iscsid.conf conn[0] timeouts"
+              if [ -f "$CONF" ]; then
+                set_conf 'node.conn[0].timeo.login_timeout' "$ISCSI_LOGIN_TIMEOUT"
+                set_conf 'node.conn[0].timeo.noop_out_interval' "$ISCSI_NOOP_OUT_INTERVAL"
+                set_conf 'node.conn[0].timeo.noop_out_timeout' "$ISCSI_NOOP_OUT_TIMEOUT"
+              else
+                echo "$(date -Iseconds) $CONF missing; skipping iscsid.conf pinning" >&2
+              fi
+              echo "iscsi-host-config: applying SCSI cmd timeout=${TIMEOUT}s to iSCSI disks every ${INTERVAL}s"
               while true; do
-                if [ -f "$CONF" ]; then
-                  set_conf 'node.conn[0].timeo.login_timeout' "$ISCSI_LOGIN_TIMEOUT"
-                  set_conf 'node.conn[0].timeo.noop_out_interval' "$ISCSI_NOOP_OUT_INTERVAL"
-                  set_conf 'node.conn[0].timeo.noop_out_timeout' "$ISCSI_NOOP_OUT_TIMEOUT"
-                else
-                  echo "$(date -Iseconds) $CONF missing; skipping iscsid.conf pinning" >&2
-                fi
                 for p in /dev/disk/by-path/*-iscsi-*; do
                   # No matches -> the literal glob string; skip it.
                   [ -e "$p" ] || continue

--- a/scsi-timeout.yaml
+++ b/scsi-timeout.yaml
@@ -1,13 +1,26 @@
-# DaemonSet: lower the SCSI command timeout for iSCSI-backed disks on every node.
+# DaemonSet: per-node iSCSI storage timeout tuning. Two duties:
+# lower the SCSI command timeout for iSCSI-backed disks, and pin
+# node.conn[0].timeo.* defaults in each host's /etc/iscsi/iscsid.conf.
 #
-# Why: /sys/block/sd*/device/timeout is a SCSI-layer attribute (default 30s),
-# NOT an iSCSI node parameter, so democratic-csi neither manages nor can manage
-# it (0 references to device/timeout in the driver). On this <1ms local L2, a 30s
-# per-command timeout means I/O to a wedged/offline iSCSI LUN blocks up to ~30s
-# before erroring, which contributes to node jam-ups. This lowers the SCSI cmd
-# timeout to a tunable value (default 10s, via the TIMEOUT env var) for iSCSI
-# disks ONLY. Local/root/non-iSCSI disks are never touched. Complements the
-# companion PR that tunes the iSCSI-layer timeouts via node-db.*.
+# Why (SCSI cmd timeout): /sys/block/sd*/device/timeout is a SCSI-layer
+# attribute (default 30s), NOT an iSCSI node parameter, so democratic-csi
+# neither manages nor can manage it (0 references to device/timeout in the
+# driver). On this <1ms local L2, a 30s per-command timeout means I/O to a
+# wedged/offline iSCSI LUN blocks up to ~30s before erroring, which contributes
+# to node jam-ups. This lowers the SCSI cmd timeout to a tunable value (default
+# 10s, via the TIMEOUT env var) for iSCSI disks ONLY. Local/root/non-iSCSI
+# disks are never touched. Complements the iSCSI-layer timeouts via node-db.*.
+#
+# Why (iscsid.conf pinning): the node.conn[0].timeo.* settings cannot ride the
+# democratic-csi node-stage secret -- Kubernetes Secret data keys must match
+# [-._a-zA-Z0-9]+, so bracket keys are rejected by the API server. democratic-csi
+# creates each iSCSI node record fresh at NodeStageVolume time and
+# `iscsiadm -o new` copies defaults from iscsid.conf, so values pinned here
+# reach every volume staged after the change -- forward-only, the same
+# semantics the node-db.* secret keys would have had. node-db.* secret keys
+# (CHAP auth, replacement_timeout) override these defaults per record, so
+# there is no overlap: bracket keys live here, bracket-free keys live on the
+# node-stage secret.
 #
 # iSCSI discrimination: iSCSI disks are identified solely by a by-path id
 # containing "-iscsi-" (e.g. /dev/disk/by-path/ip-172.16.1.118:3260-iscsi-iqn...
@@ -55,12 +68,44 @@ spec:
               value: "10"
             - name: INTERVAL
               value: "60"
+            # iscsid.conf defaults pinned on each host (see header comment).
+            # Stock open-iscsi defaults are 15/5/5, tuned for lossy fabrics;
+            # tightened for this <1ms local L2.
+            - name: ISCSI_LOGIN_TIMEOUT
+              value: "5"
+            - name: ISCSI_NOOP_OUT_INTERVAL
+              value: "2"
+            - name: ISCSI_NOOP_OUT_TIMEOUT
+              value: "2"
           command: ["/bin/sh", "-c"]
           args:
             - |
               set -eu
-              echo "scsi-timeout: applying SCSI cmd timeout=${TIMEOUT}s to iSCSI disks every ${INTERVAL}s"
+              echo "scsi-timeout: applying SCSI cmd timeout=${TIMEOUT}s to iSCSI disks and pinning iscsid.conf conn[0] timeouts every ${INTERVAL}s"
+              CONF=/etc/iscsi/iscsid.conf
+              # Pin an iscsid.conf default: replace an active line whose value
+              # differs, append when the key is absent or only commented out.
+              set_conf() {
+                key=$1
+                val=$2
+                esc=$(printf '%s' "$key" | sed 's/[].[]/\\&/g')
+                cur=$(sed -n "s/^${esc}[[:space:]]*=[[:space:]]*//p" "$CONF" | tail -n 1 | sed 's/[[:space:]]*$//')
+                if [ -z "$cur" ]; then
+                  printf '%s = %s\n' "$key" "$val" >> "$CONF"
+                  echo "$(date -Iseconds) $CONF: appended $key = $val"
+                elif [ "$cur" != "$val" ]; then
+                  sed -i "s/^${esc}[[:space:]]*=.*/${key} = ${val}/" "$CONF"
+                  echo "$(date -Iseconds) $CONF: $key ${cur} -> ${val}"
+                fi
+              }
               while true; do
+                if [ -f "$CONF" ]; then
+                  set_conf 'node.conn[0].timeo.login_timeout' "$ISCSI_LOGIN_TIMEOUT"
+                  set_conf 'node.conn[0].timeo.noop_out_interval' "$ISCSI_NOOP_OUT_INTERVAL"
+                  set_conf 'node.conn[0].timeo.noop_out_timeout' "$ISCSI_NOOP_OUT_TIMEOUT"
+                else
+                  echo "$(date -Iseconds) $CONF missing; skipping iscsid.conf pinning" >&2
+                fi
                 for p in /dev/disk/by-path/*-iscsi-*; do
                   # No matches -> the literal glob string; skip it.
                   [ -e "$p" ] || continue
@@ -107,6 +152,9 @@ spec:
             - name: dev-disk-by-path
               mountPath: /dev/disk/by-path
               readOnly: true
+            # Directory mount (not the file) so sed -i's replace-by-rename works.
+            - name: etc-iscsi
+              mountPath: /etc/iscsi
       volumes:
         - name: sys
           hostPath:
@@ -115,4 +163,8 @@ spec:
         - name: dev-disk-by-path
           hostPath:
             path: /dev/disk/by-path
+            type: Directory
+        - name: etc-iscsi
+          hostPath:
+            path: /etc/iscsi
             type: Directory


### PR DESCRIPTION
## Summary
Companion to #378. The `node.conn[0].timeo.*` tightening from 95f97dd can't be delivered via the democratic-csi node-stage secret — Kubernetes Secret data keys must match `[-._a-zA-Z0-9]+`, so bracket keys are rejected by the API server. This delivers them at the host layer instead: the DaemonSet (renamed `scsi-timeout` → `iscsi-host-config` to match its wider scope) pins `login_timeout=5`, `noop_out_interval=2`, `noop_out_timeout=2` in each host's `/etc/iscsi/iscsid.conf` via a new rw `/etc/iscsi` hostPath mount, tunable via env vars.

## Design
- **One-shot at container startup** (re-applied on pod restart), not part of the periodic sweep: the values only matter when node records are created, and the working assumption is a node reboot after the first apply brings the node fully onto the new settings.
- The existing SCSI cmd timeout sysfs sweep is unchanged.
- `node-db.*` secret keys (CHAP, `replacement_timeout`) override iscsid.conf defaults per record, so each setting keeps a single source: bracket keys here, bracket-free keys on the node-stage secret.
- App-of-apps prune is enabled, so the old `scsi-timeout` DaemonSet is removed automatically on sync.

## Behavior per key
- Active line with a different value → replaced in place
- Absent or only present commented out → appended
- Already correct → no-op
- `iscsid.conf` missing on a node → logged warning, skipped (fails visible)

## Verification (all in the actual `busybox:1.38.0` image)
- Test harness covering: append-when-commented-out, in-place update of a stale active value, append-when-missing, unrelated keys untouched, idempotent re-runs, and bracket regex escaping (`[].[]` character class — `[][.]` is malformed because POSIX treats `[.` as a collating-symbol opener; caught by the test).
- The exact script extracted from this manifest was smoke-tested against a mock `iscsid.conf`: startup pinning converges the file before the sweep loop starts.
- Confirmed busybox `sed -i` preserves 0600 on the conf file (it may hold CHAP defaults on some distros).
- kubeconform/pluto pre-commit checks passed.