### PR TITLE
feat(immich): OpenVINO iGPU for ML + PVC model cache + preload SigLIP2-384

### DIFF
--- a/immich/application.immich.yaml
+++ b/immich/application.immich.yaml
@@ -70,6 +70,40 @@ spec:
           persistence:
             library:
               existingClaim: immich
+        machine-learning:
+          enabled: true
+          controllers:
+            main:
+              # single-attach RWO cache PVC -> avoid two pods attaching during rollout
+              strategy: Recreate
+              containers:
+                main:
+                  image:
+                    repository: ghcr.io/immich-app/immich-machine-learning
+                    # OpenVINO variant -> Intel iGPU acceleration (matches server tag)
+                    tag: v3.1.0-openvino
+                  env:
+                    # Keep the CLIP model resident for fast first-search after startup.
+                    # Preload names must match the active Smart Search model set in the UI.
+                    MACHINE_LEARNING_PRELOAD__CLIP__TEXTUAL: ViT-SO400M-16-SigLIP2-384__webli
+                    MACHINE_LEARNING_PRELOAD__CLIP__VISUAL: ViT-SO400M-16-SigLIP2-384__webli
+                    # 0 = never unload models on inactivity (default 300s)
+                    MACHINE_LEARNING_MODEL_TTL: "0"
+                  resources:
+                    requests:
+                      cpu: 200m
+                      memory: 3Gi
+                      gpu.intel.com/i915: "1"
+                    limits:
+                      memory: 8Gi
+                      gpu.intel.com/i915: "1"
+          persistence:
+            cache:
+              # PVC so the multi-GB model isn't re-downloaded on every pod restart
+              enabled: true
+              type: persistentVolumeClaim
+              size: 12Gi
+              accessMode: ReadWriteOnce
         valkey:
           enabled: true
           controllers:


### PR DESCRIPTION
## Problem
Immich Smart Search does a poor job on small / less-common subjects (small cats). The machine-learning component runs on chart defaults:
- **Model:** `ViT-B-32__openai` (224px) — too low-resolution; a small subject gets averaged into the background.
- **CPU-only** — even though the cluster exposes Intel iGPUs via `intel-device-plugins-gpu`, nothing requested `gpu.intel.com/i915`.
- **`emptyDir` model cache** — re-downloads the model on every pod restart.
- **No resource requests/limits.**

## Change
Configures the previously-defaulted `machine-learning` component in the Helm values:
- OpenVINO image variant `v3.1.0-openvino` + `gpu.intel.com/i915: "1"` (requests+limits) → inference on the Intel iGPU.
- 12Gi RWO PVC for the model cache + `strategy: Recreate` (single-attach) → no re-download on restart.
- Preload `ViT-SO400M-16-SigLIP2-384__webli` (textual+visual) and `MACHINE_LEARNING_MODEL_TTL=0` → model stays resident for fast search.
- cpu/memory requests+limits (VPA for this deployment is `updateMode: Off`, so it won't override them).

## Verification
- `helm template` of chart `0.13.1` with these values renders the ML Deployment with the OpenVINO image, the i915 request, `MODEL_TTL=0`, both preload vars, and a PVC-backed `cache` volume.
- Local pre-commit `kubeconform` + `pluto` checks pass.

## Post-merge steps (not manifest-driven)
1. Confirm the ML pod schedules on a GPU node and got `gpu.intel.com/i915` (check logs for OpenVINO init).
2. Admin → Settings → Machine Learning → Smart Search → set model to `ViT-SO400M-16-SigLIP2-384__webli`.
3. Admin → Jobs → Smart Search → **All** to re-index existing assets.

The active model is deliberately left to the UI: a partial Immich config file would lock the entire settings page and reset unspecified keys to defaults.