### PR TITLE
fix(contour): 5s ext_authz response timeout for python-envoy-authz

### DIFF
--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -262,6 +262,14 @@ spec:
   validation:
     caSecret: cert-manager/k8s-ca
     subjectName: python-envoy-authz
+  # Envoy's default ext_authz response timeout (~200ms) is too tight for an
+  # authz path that does upstream I/O: a session cache miss makes Check() do a
+  # full httpx federation round-trip to Vikunja. Under that default, a slow
+  # Check() is abandoned and Envoy fails closed (ext_authz_error -> 403 UAEX).
+  # 5s gives a cold federation headroom; the gRPC handler pool (grpc_max_workers)
+  # is what keeps the common cache-hit path off this ceiling under burst.
+  timeoutPolicy:
+    response: 5s
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget


### PR DESCRIPTION
## Problem
Intermittent **403 `UAEX`** on Vikunja SPA assets during a browser login. Envoy access logs show **`ext_authz_error`** (not `ext_authz_denied`) with call durations pinned at **~200 ms** — Envoy's default ext_authz response timeout.

## Why
The `ExtensionService` set no `timeoutPolicy`, so ext_authz used Envoy's ~200 ms default. The federator's `Check()` does upstream I/O — a session cache miss triggers a full httpx federation round-trip to Vikunja — which can exceed 200 ms, so Envoy abandons the call and fails closed.

## Fix
Add `spec.timeoutPolicy.response: 5s` to the `python-envoy-authz` `ExtensionService`, giving a cold federation headroom.

Paired with nijave/python-envoy-authz#29, which raises the gRPC handler pool (4→64) so the common cache-hit path never approaches this ceiling under a parallel asset burst.

Validated: `.ci/validate.sh` → **All manifests valid**.

## Deploy
Takes effect on Argo sync / `kubectl apply` — no image rebuild.