### PR TITLE
fix(federation): bind OP auth code to Vikunja's own redirect_uri

### DIFF
--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -157,6 +157,17 @@ spec:
           # In-cluster base for federate/refresh calls (not the public mTLS host).
           - name: VIKUNJA_API_BASE
             value: "http://vikunja.default.svc.cluster.local"
+          # Must equal the redirect_uri Vikunja sends at token exchange, which
+          # it derives from its own service.publicurl as
+          # <publicurl>/auth/openid/<provider>. The browser-bootstrap flow mints
+          # the OP auth code bound to this value, but the SPA POSTs only {code}
+          # to Vikunja's callback, so Vikunja redeems it with its own computed
+          # redirect_uri; if the two differ the OP rejects the exchange
+          # (invalid_grant, "Invalid 'redirect_uri' in request"). The default
+          # (localhost:3456) only matches the federator's own server-side
+          # federate() leg, which passes redirect_url in the body.
+          - name: VIKUNJA_REDIRECT_URL
+            value: "https://vikunja.apps.somemissing.info/auth/openid/broker"
           - name: VIKUNJA_CLIENT_SECRET
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Problem

With the browser-bootstrap nav-classification fix live (python-envoy-authz#31), the front-channel login now redirects correctly, but the final code exchange fails:

```
POST /api/v1/auth/openid/broker/callback -> 400
invalid_grant — "Invalid 'redirect_uri' in request."
```

## Root cause (from the deployed OP logs)

The federator mints the OP authorization code bound to `provider.redirect_url` = `${VIKUNJA_REDIRECT_URL:-http://localhost:3456/auth/openid/broker}`, and `VIKUNJA_REDIRECT_URL` was unset. authlib validates the token-request `redirect_uri` against the code's bound value.

- **Browser flow (was failing):** the SPA POSTs only `{code}` to Vikunja's callback, so Vikunja redeems it at the OP with the redirect_uri it derives from its own `service.publicurl` — `https://vikunja.apps.somemissing.info/auth/openid/broker` — which ≠ the bound `localhost:3456` → 400.
- **API/app flow (was working):** the federator's server-side `federate()` passes `redirect_url` in the POST body, which Vikunja honors, so both sides used `localhost:3456` and matched.

## Fix

Set `VIKUNJA_REDIRECT_URL` to the redirect_uri Vikunja actually sends (`<publicurl>/auth/openid/broker`), so the bootstrap code binds it and the exchange matches. The server-side leg continues to match too (it passes the same value in the body).

## Deploy / verify

Applies on Argo sync / `kubectl apply` (no rebuild), then reloader restarts the pods. After that the browser bootstrap should complete to an authenticated session. `kubeconform` passed.