### PR TITLE
Protect HyperDX MongoDB quorum during drains

### DIFF
--- a/hyperdx-mongo.yaml
+++ b/hyperdx-mongo.yaml
@@ -149,6 +149,17 @@ spec:
               requests:
                 storage: 2Gi
 ---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hyperdx-mongo
+  namespace: hyperdx
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: hyperdx-svc
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
A three-member MongoDB replica set needs two members available to retain quorum during voluntary disruptions.