### PR TITLE
fix(hyperdx): use published MongoDB exporter tag

### DIFF
--- a/hyperdx-mongo.yaml
+++ b/hyperdx-mongo.yaml
@@ -106,7 +106,7 @@ spec:
                 limits:
                   memory: 512Mi
             - name: mongodb-exporter
-              image: percona/mongodb_exporter:2.37.0
+              image: percona/mongodb_exporter:0.52.0
               args:
                 - --collect-all
                 - --compatible-mode

--- a/renovate.json
+++ b/renovate.json
@@ -112,6 +112,11 @@
       "matchPackageNames": ["cloudflare/cloudflared"]
     },
     {
+      "description": "mongodb_exporter publishes 0.x releases; require review before a major-line change",
+      "matchPackageNames": ["percona/mongodb_exporter"],
+      "allowedVersions": "/^0\\./"
+    },
+    {
       "description": "Bump altinity-clickhouse-operator chart and CRD git ref together",
       "matchPackageNames": [
         "altinity-clickhouse-operator",


### PR DESCRIPTION
Renovate selected a Docker tag that the registry no longer serves, leaving the MongoDB exporter in ImagePullBackOff. Restrict automated updates to the established 0.x release line; a future major version requires review.