### PR TITLE
chore(deps): update CSI sidecars and snapshot-controller to current

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -177,10 +177,19 @@ spec:
           config:
             driver: ""
         controller:
+          # sidecars pinned at current releases; chart 0.15.1 defaults are
+          # 2023-era. The fork driver image (upstream v1.9.5 code,
+          # @grpc/grpc-js server, CSI 1.0-1.11 protos) is compatible with all
+          # of these, and 1.36 clears every sidecar minimum (v6 csi-provisioner
+          # needs >= 1.34).
           # expose csi_sidecar_operations_seconds so controller-side CSI op
           # latency (CreateVolume, DeleteVolume, snapshots) lands in Thanos;
           # kubelet only covers node-side ops
           externalProvisioner:
+            image:
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-provisioner
+              registry: registry.k8s.io/sig-storage/csi-provisioner
+              tag: v6.3.0
             extraArgs:
               - --http-endpoint=:8080
               # default 10; modest headroom for burst PVC churn (Woodpecker CI).
@@ -188,12 +197,24 @@ spec:
               # kept conservative so concurrent zfs/targetcli ops don't contend.
               - --worker-threads=16
           externalAttacher:
+            image:
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-attacher
+              registry: registry.k8s.io/sig-storage/csi-attacher
+              tag: v4.12.0
             extraArgs:
               - --http-endpoint=:8081
           externalResizer:
+            image:
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-resizer
+              registry: registry.k8s.io/sig-storage/csi-resizer
+              tag: v2.2.0
             extraArgs:
               - --http-endpoint=:8082
           externalSnapshotter:
+            image:
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-snapshotter
+              registry: registry.k8s.io/sig-storage/csi-snapshotter
+              tag: v8.6.0
             extraArgs:
               - --http-endpoint=:8083
           driver:
@@ -211,6 +232,11 @@ spec:
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
               tag: 390742a
+          driverRegistrar:
+            image:
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar
+              registry: registry.k8s.io/sig-storage/csi-node-driver-registrar
+              tag: v2.17.0
         csiProxy:
           image:
             # renovate: datasource=docker depName=democraticcsi/csi-grpc-proxy

--- a/application.snapshot-controller.yaml
+++ b/application.snapshot-controller.yaml
@@ -30,4 +30,11 @@ spec:
     targetRevision: 0.3.0
     helm:
       releaseName: snapshot-controller
-      valuesObject: {}
+      valuesObject:
+        controller:
+          image:
+            # renovate: datasource=docker depName=registry.k8s.io/sig-storage/snapshot-controller
+            repository: registry.k8s.io/sig-storage/snapshot-controller
+            # chart 0.3.0 appVersion is 8.2.1; keep this matched with the
+            # csi-snapshotter sidecar in application.democratic-csi.yaml
+            tag: v8.6.0

--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,8 @@
       "managerFilePatterns": ["/\\.yaml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s+\\S+?:\\s*\\S+?:(?<currentValue>[^@\\s\"']+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
-        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*registry:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?"
+        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*registry:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?",
+        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*repository:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{datasource}}{{else}}docker{{/if}}"
     }
@@ -145,6 +146,18 @@
         "registry.k8s.io/autoscaling/vpa-admission-controller"
       ],
       "groupName": "vpa"
+    },
+    {
+      "description": "democratic-csi sidecars and snapshot-controller — csi-snapshotter and snapshot-controller must stay on the same version, and the sidecar set is validated together upstream (k8s e2e bumps them in lockstep)",
+      "matchPackageNames": [
+        "registry.k8s.io/sig-storage/csi-provisioner",
+        "registry.k8s.io/sig-storage/csi-attacher",
+        "registry.k8s.io/sig-storage/csi-resizer",
+        "registry.k8s.io/sig-storage/csi-snapshotter",
+        "registry.k8s.io/sig-storage/snapshot-controller",
+        "registry.k8s.io/sig-storage/csi-node-driver-registrar"
+      ],
+      "groupName": "csi-sidecars"
     },
     {
       "description": "Only update kube-prometheus-stack on Fridays",


### PR DESCRIPTION
## What

Pins the democratic-csi CSI sidecars at current releases instead of riding chart 0.15.1's 2023-era defaults (these were the four oldest images in the 2026-08-14 image-age report), and moves snapshot-controller to match.

| Image | From (chart default) | To |
|---|---|---|
| csi-provisioner | v3.6.0 | v6.3.0 |
| csi-attacher | v4.4.0 | v4.12.0 |
| csi-resizer | v1.9.0 | v2.2.0 |
| csi-snapshotter | v8.2.1 | v8.6.0 |
| csi-node-driver-registrar | v2.9.0 | v2.17.0 |
| snapshot-controller | v8.2.1 (chart appVersion) | v8.6.0 |

## Why now / compatibility

- Driver compatibility verified against the running fork image (`390742a`, upstream v1.9.5 code): `@grpc/grpc-js` server, CSI 1.0-1.11 protos shipped, full identity/controller/node RPC surface. All current sidecar majors require CSI 1.0-1.12 at most and remain wire-compatible; none removed flags the chart passes (`--http-endpoint`, `--worker-threads`, `--workers`, etc.).
- Cluster is 1.36, which clears every minimum: provisioner v6.0.0 needs K8s >= 1.34 (VolumeAttributesClass GA); attacher v4.x ~1.17, resizer v2.x 1.16, snapshotter v8.x 1.25, registrar v2.x 1.13.
- snapshot-controller and csi-snapshotter are released from the same repo and should stay on the same version — the controller app gets a `repository`+`tag` override since chart 0.3.0's appVersion is 8.2.1.
- Snapshot CRDs are already v1 (running v8.2.x today); v8.6.0 needs no CRD change.

## Renovate wiring

- Sidecar pins follow the existing `# renovate:` + `registry:`/`tag:` pattern so the custom regex manager tracks them.
- `renovate.json`: adds a `repository:`+`tag:` regex variant (for the snapshot-controller chart's image structure) and a `csi-sidecars` group rule so future bumps to all six arrive as one PR (mirrors the existing vpa/exportarr group rules).

## Rollout

Argo auto-syncs on merge: the controller Deployment and node DaemonSet roll (running pods keep their mounts; provisioning pauses briefly mid-roll), snapshot-controller (3 replicas) rolls in place. Driver image and csi-grpc-proxy are unchanged.

Validation: `validate.sh`, `validate-pluto.sh`, `validate-helm.sh` all pass locally (same as CI), and rendered output confirmed to carry the six new tags.