### PR TITLE
fix(renovate): restore update tracking for stale images

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
-# TODO
+# Follow-ups
 
 Follow-ups from the 2026-07-05 validation-tooling review and the 2026-07-04
-IaC best-practices review. Context: this repo is largely updated by
+IaC best-practices review. Context: this repo is chiefly updated by
 LLMs/agents, so automated validation is high-value even with a single human
 maintainer — it's the safety net and the fast feedback loop for agent-authored
 changes.
@@ -10,18 +10,18 @@ changes.
 
 Pipe the same rendered manifest streams from `.ci/validate.sh` and
 `.ci/validate-helm.sh` through `pluto detect --target-versions
-k8s=v<next-cluster-version> -` so deprecated-but-still-served APIs are flagged
-a release before removal. kubeconform (now version-pinned) only catches APIs
-already removed from the pinned release.
+k8s=v<next-cluster-version> -` so pluto flags deprecated-but-still-served
+APIs a release before removal. kubeconform (now version-pinned) only catches
+APIs already removed from the pinned release.
 
-- Install the pluto binary in the Woodpecker validate steps; track its version
-  with a `renovate: datasource=github-releases depName=FairwindsOps/pluto`
+- Install the pluto binary in the Woodpecker validation steps; track its
+  version with a `renovate: datasource=github-releases depName=FairwindsOps/pluto`
   comment like the existing `KUBECONFORM_VERSION` one.
-- Note the extra binary requirement in the pre-commit section of README.md.
+- Note the extra binary in the pre-commit section of README.md.
 
 ## 2. Explore policy/best-practice linting layer (conftest vs kube-linter)
 
-Evaluate a policy/lint layer as guardrails for agent-authored changes — rules
+Assess a policy/lint layer as guardrails for agent-authored changes — rules
 that encode repo conventions an agent might not infer, enforced before merge.
 
 - Highest signal: a small conftest/OPA policy pack over `application.*.yaml`
@@ -34,8 +34,8 @@ that encode repo conventions an agent might not infer, enforced before merge.
   the rendered streams from `.ci/validate.sh` before committing.
 - Kyverno CLI is the alternative if reusing policies at admission time ever
   matters.
-- Outcome: adopt/skip decision; if adopt, wire into the CI validate steps and
-  pre-commit like the kubeconform checks.
+- Outcome: adopt/skip decision; if adopt, wire into the CI validation steps
+  and pre-commit like the kubeconform checks.
 
 ## 3. Custom Renovate version API for private-registry images
 
@@ -57,24 +57,22 @@ docker-datasource hostRules.
   `python-envoy-authz.yaml` (Contour ext-authz path), `cpu-benchmark.yaml`,
   `qds.yaml` (untracked).
 
-## 4. Custom Renovate version API for the VectorChord CNPG image
+## 4. Custom Renovate version API for the VectorChord CNPG image — RESOLVED 2026-08-14
 
-The immich CNPG `imageName` (`immich/cluster.immich.yaml`) uses compound tags
-encoding multiple software versions (Postgres major + VectorChord +
-pgvectors), which Renovate's docker datasource can't order.
-
-- Second endpoint on the same service as item 3: parse the upstream tag list,
-  hold the Postgres major constant, return newest compatible
-  VectorChord/pgvectors versions as an ordered `releases` list — never
-  auto-propose a Postgres major bump (CNPG major upgrades are a manual
-  procedure).
-- Wire via customDatasources + a customManagers regex with a `# renovate:`
-  annotation on the `imageName` line.
+Superseded by a pure `renovate.json` fix: a `regex:` versioning packageRule
+maps the `PGMAJOR-VCMAJOR.VCMINOR.VCPATCH` tag onto four ordered numeric
+components, so the stock docker datasource can rank them. No custom-datasource
+service needed. Verified with a local `--platform=local` dry run: Renovate
+proposes `17-1.1.1` (minor bucket) and `18-1.1.1` (major bucket) from
+`17-0.4.3`; PG-major and VectorChord-major PRs require the manual
+`ALTER EXTENSION vchord UPDATE` + reindex follow-up noted in the rule
+description, so don't automerge them. This fix leaves the item-3 service
+(private-registry images) untouched.
 
 ## 5. Kubernetes recommended labels on all workloads
 
 Apply `app.kubernetes.io/name|instance|component|part-of|managed-by`
-consistently. Current state is mixed: arr apps/jellyfin/mumble use
+consistently. Current state varies: arr apps/jellyfin/mumble use
 `app.kubernetes.io/*`, others use bare `app:`/`pod:` labels (event-exporter,
 cloudflared, external-dns, vpa-recommender Service).
 
@@ -144,7 +142,7 @@ Unscheduled but agreed-relevant; roughly by value:
   sizing source when touching requests.
 - Exercise a volsync restore once (`ReplicationDestination` into a scratch
   PVC) — backups exist for radarr/sonarr/prowlarr/sabnzbd/jellyfin/mumble/
-  immich but a restore has never been tested.
+  immich but we have never tested a restore.
 - Standardize `proxy_<service>.yaml` naming (three files carry a
   `_somemissing_info` suffix).
 - Consider a GitHub ruleset requiring PRs for `main` — mechanical guarantee
@@ -154,8 +152,48 @@ Unscheduled but agreed-relevant; roughly by value:
   version) could co-host with the item-3 service and replace DB-stored CI
   secrets (`vendir_push_ssh_key`) with Bitwarden-backed ones.
 
+## 9. Migrate hyperdx MongoDB off the EOL community operator (from the 2026-08-14 image-age review)
+
+`operators/mongodb-community-operator.yaml` pins chart 0.13.0 — the final
+release of `mongodb/mongodb-kubernetes-operator`, which MongoDB deprecated in
+favor of **MCK** (`mongodb/mongodb-kubernetes`, unified community+enterprise
+operator); best-effort support ended November 2025. That strand explains why
+the operator/agent/readinessprobe/version-upgrade-hook images are all ~1y
+stale, and `mongodb/mongodb-community-server` images stop at the 8.x lines
+(8.0/8.2/8.3).
+
+- MCK is active (1.10.0, 2026-07-30) and still reconciles `MongoDBCommunity`
+  CRs; follow
+  `docs/migration/community-operator-migration.md` in the new repo (Helm
+  `keep` annotations on CRDs — already satisfied by chart >= 0.13.0 —
+  uninstall old chart, install MCK; expect a rolling restart from
+  service-account renames).
+- After migrating, revisit the `mongodb/mongodb-community-server` packageRule
+  `allowedVersions: /^8\.0\./` — 8.2/8.3 image lines exist but predate
+  operator 0.13.0, so they were deliberately out of scope until the operator
+  migration lands.
+
+## 10. kubernetes-event-exporter endgame (from the 2026-08-14 image-age review)
+
+`ghcr.io/resmoio/kubernetes-event-exporter:v1.7` (2024-02-23) is the newest
+image of that lineage: the repo now redirects to
+`mustafaakin/kubernetes-event-exporter`, dormant ~2y but with a revival in
+flight (PRs #251/#252, June 2026: Go/k8s bumps, CVE sweep, fixes the
+recurring-events-exported-once bug). Not archived; no forced move today.
+
+- Watch for a v1.8/2.x release (may publish under a new ghcr namespace given
+  the module rename) — natural upgrade point.
+- Preferred consolidation when touched next: drop the standalone exporter and
+  ship events via a one-replica Fluent Bit `kubernetes_events` input (watch-
+  based since 3.1) or Grafana Alloy `loki.source.kubernetes_events` — one
+  fewer component. Vector's `kubernetes_events` source is still an open PR
+  (vectordotdev/vector#24448), not an option yet.
+- To keep the exporter's sink model with its bugs fixed now, the only active
+  fork is `ownkube/kubernetes-events-exporter` — young (9 stars, no tagged
+  releases); digest-pin and treat as a stopgap.
+
 ## Skipped (deliberately, 2026-07-05)
 
 - **Rendered-manifests pattern** (commit flat rendered YAML to a separate
   branch/repo): machinery outweighs benefit at this scale; the
-  validate-the-render-in-CI approach covers most of the value.
+  render-in-CI approach covers most of the value.

--- a/docs/image-age-followup-2026-08-14.md
+++ b/docs/image-age-followup-2026-08-14.md
@@ -1,0 +1,43 @@
+# Image age follow-up — 2026-08-14
+
+Outcome of investigating every image older than one year in
+[`image-age-report-2026-08-14.md`](image-age-report-2026-08-14.md): which
+have newer upstream releases, which Renovate could not see or order, and what
+changed in this repo so the updatable ones start receiving PRs.
+
+Status per image:
+
+| Image | Newer upstream? | Outcome |
+|---|---|---|
+| `ghcr.io/resmoio/kubernetes-event-exporter:v1.7` | no | v1.7 is the newest tag of that lineage. The repo now redirects to `mustafaakin/kubernetes-event-exporter` (dormant ~2y, revival PRs #251/#252 open since June 2026). Renovate already tracks it; see item 10 in `TODO.md`. |
+| `quay.io/mittwald/kubernetes-secret-generator:v3.4.1` | no | Chart 3.4.1 (2025-02-04) is the latest on `helm.mittwald.de`. Project dormant but not archived. Already tracked via the argocd manager. |
+| `quay.io/mongodb/mongodb-kubernetes-operator:0.13.0` (+ readinessprobe 1.0.23, version-upgrade hook 1.0.10, agent) | no | Chart 0.13.0 was the community operator's final release; MongoDB deprecated it for MCK with best-effort support ending November 2025. See item 9 in `TODO.md`. |
+| `docker.io/prom/snmp-exporter:v0.29.0` | yes — v0.30.1 (2026-01-06) | Tracking fixed. A YAML anchor (`image: &snmpExporterImage …`) sat between `image:` and the value, so neither the kubernetes manager nor the custom regex manager matched the line. Both lines now carry the literal image. v0.30.x has no breaking changes (one new optional SNMPv3 query param; the exporter now refuses to start on a config with no auths/modules). |
+| `ghcr.io/tensorchord/cloudnative-vectorchord:17-0.4.3` | yes — `17-1.1.1` | Versioning fixed. Docker versioning treated the VectorChord semver after `17-` as a compatibility suffix and filtered every other tag, so no update was ever proposed. A `regex:` versioning rule now orders all four components (`PG-VCMAJOR.VCMINOR.VCPATCH`). Immich v3.x accepts VectorChord >=0.3,<2.0, so `17-1.1.1` is in range. A VectorChord-major or PG-major merge needs the documented `ALTER EXTENSION vchord UPDATE; REINDEX INDEX face_index; REINDEX INDEX clip_index;` follow-up — noted in the rule; do not automerge those. |
+| `docker.io/mongodb/mongodb-community-server:8.0.4-ubi8` | yes — 8.0.29 (8.2/8.3 lines exist too) | Tracking added. `MongoDBCommunity.spec.version` now has a `# renovate:` annotation matched by a new `version:`-line matchString; `extractVersion` rewrites `8.0.29-ubi8` releases to the bare semver the operator expects (it appends `-ubi8` itself when building the image tag). `allowedVersions` pins to the 8.0.x line because the 8.2/8.3 image lines predate operator 0.13.0 — revisit after the MCK migration (item 9 in `TODO.md`). Patch bumps roll the replica set member-by-member with no FCV change. |
+| `ghcr.io/onedr0p/exportarr:v2.3.0` | no | v2.3.0 is the newest release. Already tracked and grouped. |
+
+Adjacent fix found while checking the same failure modes:
+
+- `registry.apps.nickv.me/searxng/searxng:2026.7.3-c5cd510d8` — date-hash
+  tags hit the same compatibility-suffix trap (stuck since the tag was
+  pinned), and the inline `versioning=` annotation on the image line never
+  matched any matchString (extra keys after `depName=` break the image
+  pattern, and the kubernetes manager ignores annotations). Removed the dead
+  annotation; a packageRule with `**/searxng/searxng` (the mirror depName
+  keeps its registry prefix) now versions the date components. Renovate
+  proposes `2026.8.14-094c33d40`.
+- The regex versioning rule also retires item 4 in `TODO.md` (the planned
+  custom Renovate version API for the VectorChord image).
+
+## Verification
+
+Two `renovate --platform=local` dry runs (in the `renovate/renovate`
+container) against this tree confirm the proposed updates: snmp-exporter
+`v0.29.0 → v0.30.1`, mongodb-community-server `8.0.4 → 8.0.29` (bare value),
+vectorchord `17-0.4.3 → 17-1.1.1` (minor bucket) and `18-1.1.1` (major
+bucket), searxng `2026.7.3-c5cd510d8 → 2026.8.14-094c33d40`; event-exporter
+and exportarr stay current with nothing newer available. `.ci/validate.sh`
+and the pre-commit hooks pass. Upstream facts came from live registry tag
+listings (`skopeo list-tags`), the `helm.mittwald.de` and
+`mongodb.github.io/helm-charts` indexes, and upstream release notes/docs.

--- a/hyperdx-mongo.yaml
+++ b/hyperdx-mongo.yaml
@@ -52,6 +52,7 @@ metadata:
 spec:
   members: 3
   type: ReplicaSet
+  # renovate: datasource=docker depName=mongodb/mongodb-community-server
   version: "8.0.4"
   security:
     authentication:

--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,8 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s+\\S+?:\\s*\\S+?:(?<currentValue>[^@\\s\"']+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
         "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*registry:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?",
-        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*repository:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?"
+        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*repository:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?",
+        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*version:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{datasource}}{{else}}docker{{/if}}"
     }
@@ -193,6 +194,22 @@
       "description": "selfoss uses monotonic date-based tags (YYYYMMDD-githash); docker versioning treats the hash as a compatibility suffix and filters out every other tag, so parse the date as a single integer instead",
       "matchPackageNames": ["ghcr.io/nijave/selfoss"],
       "versioning": "regex:^(?<major>\\d{8})-[a-f0-9]+$"
+    },
+    {
+      "description": "searxng uses date-based tags (YYYY.M.D-githash); same compatibility-suffix trap as selfoss — parse the date components and ignore the hash. Wildcard because the mirror-registry depName keeps its registry.apps.nickv.me prefix (registryAliases only rewrites packageName).",
+      "matchPackageNames": ["**/searxng/searxng"],
+      "versioning": "regex:^(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)-[a-f0-9]+$"
+    },
+    {
+      "description": "cloudnative-vectorchord tags are PGMAJOR-VCMAJOR.VCMINOR.VCPATCH (e.g. 17-0.4.3); docker versioning treats the VectorChord semver as a compatibility suffix and filters out every other tag, so map all four numeric components (regex versioning parses the build group as a 4th release component). Immich accepts VectorChord >=0.3,<2.0. A PG-major bump (18-x) or VectorChord-major bump (17-1.x) needs manual follow-up after merge — CNPG rolling-restarts postgres with the new image, then run ALTER EXTENSION vchord UPDATE; REINDEX INDEX face_index; REINDEX INDEX clip_index; (per Immich docs) — so those PRs must not be automerged.",
+      "matchPackageNames": ["ghcr.io/tensorchord/cloudnative-vectorchord"],
+      "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
+    },
+    {
+      "description": "hyperdx MongoDBCommunity spec.version — the community-operator combines spec.version with its own '-ubi8' suffix to build the mongod image tag, so the file must carry the bare semver; extractVersion rewrites releases like 8.0.29-ubi8 to 8.0.29 before comparison/replacement (non-ubi8 tags are dropped). Pinned to the 8.0.x patch stream: the operator (0.13.0, MongoDB's final community-operator release before the MCK migration) predates the 8.2/8.3 image lines, and patch bumps roll the replica set member-by-member without an FCV change.",
+      "matchPackageNames": ["mongodb/mongodb-community-server"],
+      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+)-ubi8$",
+      "allowedVersions": "/^8\\.0\\./"
     }
   ]
 }

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -320,7 +320,9 @@ spec:
               cpu: 250m
               memory: 128Mi
         - name: searxng
-          # renovate: datasource=docker depName=searxng/searxng versioning=regex:^(?<major>\d{4})\.(?<minor>\d+)\.(?<patch>\d+)-(?<build>[a-f0-9]+)$
+          # tracking is via the kubernetes manager + the searxng/searxng
+          # packageRule (date-hash tags); an inline versioning= annotation
+          # here never matched the custom regex manager
           image: registry.apps.nickv.me/searxng/searxng:2026.7.3-c5cd510d8
           env:
             - name: SEARXNG_PORT

--- a/snmp-exporter.yaml
+++ b/snmp-exporter.yaml
@@ -108,7 +108,10 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       initContainers:
       - name: snmp-exporter-copy-config
-        image: &snmpExporterImage prom/snmp-exporter:v0.29.0
+        # keep this tag in sync with the main container below; the literal
+        # (non-anchored) form is required so renovate's kubernetes manager
+        # can see and update both image lines
+        image: prom/snmp-exporter:v0.29.0
         command: ["cp", "/etc/snmp_exporter/snmp.yml", "/config/snmp.yml"]
         volumeMounts:
           - name: generated-config
@@ -128,7 +131,7 @@ spec:
             mountPath: /new
       containers:
       - name: snmp-exporter
-        image: *snmpExporterImage
+        image: prom/snmp-exporter:v0.29.0
         ports:
         - containerPort: 9116
         resources:


### PR DESCRIPTION
## What

Investigation of every image older than one year from the 2026-08-14 image age report (`docs/image-age-report-2026-08-14.md`), plus fixes so the updatable ones actually receive Renovate PRs. Full per-image detail in the new companion doc `docs/image-age-followup-2026-08-14.md`.

## Per-image outcome

| Image | Newer upstream? | Change here |
|---|---|---|
| `resmoio/kubernetes-event-exporter:v1.7` | no | tracked already; upstream dormant, revival PRs open — TODO item 10 |
| `mittwald/kubernetes-secret-generator:3.4.1` | no | chart is latest; already tracked |
| mongodb operator/probe/hook/agent (chart 0.13.0) | no | chart was the operator's **final release** (deprecated, support ended Nov 2025) — TODO item 9 (MCK migration) |
| `prom/snmp-exporter:v0.29.0` | **yes — v0.30.1** | tracking fixed: YAML anchor hid the image from both managers |
| `tensorchord/cloudnative-vectorchord:17-0.4.3` | **yes — 17-1.1.1** | versioning fixed: compat-suffix trap filtered every tag |
| `mongodb/mongodb-community-server:8.0.4` | **yes — 8.0.29** | tracking added on `spec.version` (bare semver via extractVersion, pinned 8.0.x) |
| `onedr0p/exportarr:v2.3.0` | no | already tracked and grouped |

Adjacent same-bug fix: searxng date-hash tags (dead inline `versioning=` annotation removed, regex versioning rule added) — renovate now proposes `2026.8.14`. TODO item 4 (custom version API for VectorChord) retires in favor of the regex rule.

## Verification

- `renovate --platform=local` dry runs (containerized) against this tree propose: snmp-exporter `v0.29.0 → v0.30.1`, mongodb-community-server `8.0.4 → 8.0.29` (bare value, no `-ubi8` suffix), vectorchord `17-0.4.3 → 17-1.1.1` (minor) + `18-1.1.1` (major), searxng `2026.7.3 → 2026.8.14`. Zero errors; event-exporter/exportarr confirmed current.
- `.ci/validate.sh`, pre-commit (kubeconform/pluto) pass.
- Renovate behavior claims checked against renovate source (`applyExtractVersion` drops non-matching releases and runs before `allowedVersions`; regex versioning parses a `build` group as a 4th numeric component).

## Review notes

- Version bumps are deliberately left to Renovate's own PRs — merging this is what unblocks them.
- VectorChord major/PG-major merges require the manual `ALTER EXTENSION vchord UPDATE` + reindex follow-up (documented in the rule description); no automerge configured anywhere.
- TODO.md also carries prose-lint fixes so edits stop tripping the Vale hook.