### PR TITLE
feat: scrape rtorrent-exporter with prometheus-ext

### DIFF
--- a/scrapeconfig-rtorrent-exporter.yaml
+++ b/scrapeconfig-rtorrent-exporter.yaml
@@ -1,0 +1,21 @@
+# Scrape config for the rtorrent-exporter on vmubttorrent01
+# (mdshack/rtorrent-exporter, host networking, port 9135).
+#
+# No basicAuth: the exporter's /metrics endpoint is unauthenticated. The
+# container only passes --rtorrent.username/--rtorrent.password (credentials
+# for rTorrent's XML-RPC via nginx, internal to the box), not
+# --telemetry.username/--telemetry.password, so scraping needs no credential
+# and none has to live in Kubernetes or git. The port is LAN-reachable only.
+# If that ever changes, add --telemetry.username/--telemetry.password in the
+# container's start.sh and a basicAuth block here.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: rtorrent-exporter
+  namespace: monitoring
+  labels:
+    prometheus: ext
+spec:
+  staticConfigs:
+  - targets:
+    - vmubttorrent01.homelab.somemissing.info:9135


### PR DESCRIPTION
Adds a `ScrapeConfig` (picked up by the `ext` Prometheus via its `scrapeConfigSelector: {prometheus: ext}`) for the rtorrent-exporter on `vmubttorrent01.homelab.somemissing.info:9135` (host-networked mdshack/rtorrent-exporter inside the rtorrent container). Metrics land in prometheus-ext and remote-write to Thanos (tenant `ext`).

**No credentials needed:** the exporter's `/metrics` endpoint is unauthenticated. It only receives `--rtorrent.username/--rtorrent.password` in its start.sh — credentials for rTorrent's XML-RPC behind nginx, internal to the box — and never `--telemetry.username/--telemetry.password`, which is the pair that would protect the metrics endpoint. Verified by curl: unauthenticated `GET /metrics` → 200. The port is LAN-reachable only; if that ever changes, add the `--telemetry.*` flags in the container and a matching `basicAuth` block here.

**Context:** on 2026-08-15 rtorrent's event loop wedged between 02:02 and 02:04 UTC (last successful RPC2 → first 504) and nothing noticed for 12.5 hours — the exporter was running but scraped by no one. This scrape is the data source for the alert rules in the companion rules PR (#419).