### PR TITLE
feat: add vmubttorrent01 VPN and rtorrent alert rules

### DIFF
--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -219,6 +219,27 @@ spec:
                 for: 2m
                 labels:
                   severity: warning
+          # vmubttorrent01 torrent/VPN box. Metrics come from the vpn-probe
+          # textfile collector on the host (cron writes
+          # /var/lib/prometheus/node-exporter/vpn.prom every 5m; source of
+          # truth lives in the infra workspace under hosts/vmubttorrent01/).
+          # probe_success ANDs three checks: WireGuard interface present,
+          # kernel route resolution lands on air-ca, handshake < 5m old. The
+          # route check is the one that matters: on 2026-08-12 a systemd
+          # upgrade restarted networkd and wiped wg-quick's policy rules
+          # while the interface and handshake stayed healthy.
+          vmubttorrent01:
+            groups:
+            - name: ./vmubttorrent01.rules
+              rules:
+              - alert: VpnTunnelUnusable
+                annotations:
+                  summary: vmubttorrent01 VPN tunnel is not passing traffic.
+                  description: "vpn-probe has failed for 10m. Check node_vpn_interface_up, node_vpn_default_route_via_tunnel, and node_vpn_handshake_age_seconds to see which check broke: a missing route with a healthy handshake means policy routing was wiped (systemd-networkd restart; 2026-08-12 incident), a stale handshake means the AirVPN peer or upstream path is down. 'systemctl restart wg-quick@air-ca' restores routing."
+                expr: node_vpn_probe_success != 1 or absent(node_vpn_probe_success)
+                for: 10m
+                labels:
+                  severity: critical
         prometheus:
           service:
             annotations:

--- a/rtorrent-alerts.yaml
+++ b/rtorrent-alerts.yaml
@@ -1,0 +1,50 @@
+# Alert rules for the rtorrent stack on vmubttorrent01, evaluated by the
+# `ext` Prometheus (ruleSelector matchLabels prometheus: ext). Metrics come
+# from the rtorrent-exporter scrape added in the companion ScrapeConfig PR;
+# without it these rules fire as absent/unknown until that job exists.
+#
+# 2026-08-15 incident context: rtorrent's event loop wedged between 02:02
+# (last successful RPC2 response) and 02:04 UTC (first 504). The process
+# kept listening on its SCGI socket but never accept()ed, so the exporter's
+# /metrics hung too — surfacing as up == 0 rather than any rtorrent_* gauge
+# going stale. A container restart recovered it.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rtorrent-alerts
+  namespace: monitoring
+  labels:
+    prometheus: ext
+spec:
+  groups:
+  - name: rtorrent
+    rules:
+    - alert: RtorrentExporterScrapeFailing
+      annotations:
+        summary: rtorrent-exporter on vmubttorrent01 is not scrapeable.
+        description: >-
+          The rtorrent-exporter scrape has failed for 10m. When rtorrent's
+          SCGI event loop wedges (2026-08-15: frozen 02:02-14:40 UTC) the
+          exporter's /metrics hangs with it and reads as down; the same alert
+          covers exporter crashes and credential expiry. Check RPC2 health
+          from the box: docker exec rtorrent curl -s -o /dev/null -w '%{http_code}'
+          -u admin:$PW http://127.0.0.1:5000/RPC2 --d '<methodCall><methodName>system.client_version</methodName></methodCall>'.
+          A 504 means rtorrent itself is wedged; restart with
+          'cd /mnt/docker && docker compose restart rtorrent'.
+      expr: up{job="rtorrent-exporter"} != 1 or absent(up{job="rtorrent-exporter"})
+      for: 10m
+      labels:
+        severity: critical
+    - alert: RtorrentNoProgressWithIncomplete
+      annotations:
+        summary: rtorrent has incomplete downloads but no download progress for 6h.
+        description: >-
+          rtorrent_downloads_incomplete > 0 while cumulative downloaded bytes
+          have not moved in 6h. Either everything genuinely has no available
+          peers, or rtorrent is partially wedged while still serving RPC.
+          Cross-check node_vpn_probe_success (VPN path) and tracker state
+          in Flood before restarting.
+      expr: rtorrent_downloads_incomplete > 0 and increase(rtorrent_downloads_download_total_bytes[6h]) == 0
+      for: 30m
+      labels:
+        severity: warning


### PR DESCRIPTION
Two alerting layers for vmubttorrent01, both born from real August incidents that went undetected for hours.

**1. `VpnTunnelUnusable` (prom-kp, `application.kube-prometheus.yaml`)** — fires on `node_vpn_probe_success`, a node-exporter textfile metric written every 5 min by `/usr/local/bin/vpn-probe-metrics.sh` on the box (source mirrored in the infra workspace under `hosts/vmubttorrent01/`). The probe ANDs three checks: WireGuard interface present, kernel route resolution (`ip route get`) lands on `air-ca`, handshake < 5 min old.

The route check is the one that matters: on **2026-08-12** an unattended systemd upgrade restarted `systemd-networkd`, which wiped wg-quick's foreign routing policy rules (`ManageForeignRoutingPolicyRules=yes` default). Interface and handshake stayed healthy for 2 d 18 h while every packet bypassed the tunnel — rtorrent (bound to the tunnel IP) was dead the whole time. The box now carries an `networkd.conf` drop-in disabling that behavior; this alert is the detection half.

A stopgap `PrometheusRule` named `prom-kp-vmubttorrent01` is already applied in-cluster (live and healthy); this PR is its Git-side counterpart — helm generates the identically-named object on sync, so they converge with no conflict.

**2. `rtorrent-alerts.yaml` (ext Prometheus)** — `RtorrentExporterScrapeFailing` (`up != 1 or absent`, critical) and `RtorrentNoProgressWithIncomplete` (warning). On **2026-08-15** rtorrent's event loop wedged at ~02:02 UTC; the process kept listening but never accept()ed, the exporter's `/metrics` hung with it, and nothing noticed for 12.5 h until manual triage. The wedge reads as `up == 0`, and the alert's runbook line gives the RPC2 probe + restart commands.

Depends on #418 for the `rtorrent-exporter` job to exist — merge that first.