### PR TITLE
fix(mongodb): revert 8.0.29 upgrade, pin renovate to 8.0.4 (kernel 7.0 gate)

### DIFF
--- a/hyperdx-mongo.yaml
+++ b/hyperdx-mongo.yaml
@@ -53,7 +53,7 @@ spec:
   members: 3
   type: ReplicaSet
   # renovate: datasource=docker depName=mongodb/mongodb-community-server
-  version: "8.0.29"
+  version: "8.0.4"
   security:
     authentication:
       modes:

--- a/renovate.json
+++ b/renovate.json
@@ -206,10 +206,10 @@
       "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
     },
     {
-      "description": "hyperdx MongoDBCommunity spec.version — the community-operator combines spec.version with its own '-ubi8' suffix to build the mongod image tag, so the file must carry the bare semver; extractVersion rewrites releases like 8.0.29-ubi8 to 8.0.29 before comparison/replacement (non-ubi8 tags are dropped). Pinned to the 8.0.x patch stream: the operator (0.13.0, MongoDB's final community-operator release before the MCK migration) predates the 8.2/8.3 image lines, and patch bumps roll the replica set member-by-member without an FCV change.",
+      "description": "hyperdx MongoDBCommunity spec.version — the community-operator combines spec.version with its own '-ubi8' suffix to build the mongod image tag, so the file must carry the bare semver; extractVersion rewrites releases like 8.0.29-ubi8 to 8.0.29 before comparison/replacement (non-ubi8 tags are dropped). Pinned to exactly 8.0.4, not the 8.0.x stream: mongod 8.0.29 refuses to start on Linux kernel >=6.19 (SERVER-121912 fatal version gate; the cluster workers run 7.0.0 — observed crashing hyperdx-1 after PR #420), while 8.0.4 starts fine with the MONGODB_CONFIG_OVERRIDE_NOTCMALLOC bypass in hyperdx-mongo.yaml. Where the gate first appears in the 8.0.x stream is unverified. Re-pin to a newer stream only after a release confirmed to start on this kernel.",
       "matchPackageNames": ["mongodb/mongodb-community-server"],
       "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+)-ubi8$",
-      "allowedVersions": "/^8\\.0\\./"
+      "allowedVersions": "8.0.4"
     }
   ]
 }


### PR DESCRIPTION
## Why

PR #420 bumped `hyperdx-mongo.yaml` to 8.0.29. mongod 8.0.29 refuses to start
on Linux kernel >=6.19 (`SERVER-121912` fatal version gate — see the crash on
`hyperdx-1`: `MongoDB cannot start: Linux kernel versions 6.19 and newer has a
known incompatibility with this version of MongoDB`). Every worker node runs
kernel 7.0.0, so the member crash-loops and the replica set sits at 2/3 with
the CR in `Pending`.

8.0.4 runs fine on this kernel with the existing
`MONGODB_CONFIG_OVERRIDE_NOTCMALLOC` bypass (hyperdx-0/2 have been up 21h).

## What

- `git revert` of #420: `spec.version` back to `8.0.4`.
- `renovate.json`: `allowedVersions` for `mongodb/mongodb-community-server`
  narrowed from the 8.0.x stream to exactly `8.0.4`, so renovate doesn't
  re-propose 8.0.29 within hours. Re-pin only after a release is confirmed to
  start on kernel 7.0 (where the gate first appears in the 8.0.x stream is
  unverified — only 8.0.29-fails/8.0.4-works is observed).

## After merge

The operator rolls `hyperdx-1` back to the 8.0.4 image; phase should return to
`Running`. Then the MCK migration (#422) proceeds against a stable 8.0.4 set.