### PR TITLE
fix: match ScrapeConfig job naming in rtorrent alerts

### DIFF
--- a/rtorrent-alerts.yaml
+++ b/rtorrent-alerts.yaml
@@ -31,7 +31,10 @@ spec:
           -u admin:$PW http://127.0.0.1:5000/RPC2 --d '<methodCall><methodName>system.client_version</methodName></methodCall>'.
           A 504 means rtorrent itself is wedged; restart with
           'cd /mnt/docker && docker compose restart rtorrent'.
-      expr: up{job="rtorrent-exporter"} != 1 or absent(up{job="rtorrent-exporter"})
+      # The operator renders ScrapeConfig jobs as
+      # "scrapeConfig/<namespace>/<name>", so match on a regex rather than
+      # the bare CR name.
+      expr: up{job=~"scrapeConfig/.*/rtorrent-exporter"} != 1 or absent(up{job=~"scrapeConfig/.*/rtorrent-exporter"})
       for: 10m
       labels:
         severity: critical


### PR DESCRIPTION
Follow-up to #418/#419. The prometheus-operator renders a `ScrapeConfig` job as `scrapeConfig/<namespace>/<name>` — `scrapeConfig/monitoring/rtorrent-exporter` here — not the bare CR name. `RtorrentExporterScrapeFailing` matched `job="rtorrent-exporter"`, which never matches, so the `absent()` branch held the alert permanently pending even with the scrape green.

Verified live: with the regex matcher the alert clears (`ALERTS` empty, target `up` under the prefixed job name on both ext replicas). The in-cluster `PrometheusRule rtorrent-alerts` already carries this exact expr — this PR keeps Git from reverting it when the root app finishes syncing.