### PR TITLE
chore(democratic-csi): bump driver to f161853, enable node-DB sweeper

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -103,6 +103,13 @@ spec:
             iscsi:
               sessionReaper:
                 enabled: true
+              # node-DB records orphaned by driver restarts/reboots/unstage
+              # failures are never cleaned otherwise and lengthen every
+              # iscsiadm critical section; one-shot startup sweep deletes
+              # records whose target has no active session
+              nodeDbSweeper:
+                enabled: true
+                targetBasename: "iqn.2025-04.info.somemissing.homelab:ubthv01:"
   data:
   - secretKey: privateKey
     remoteRef:
@@ -221,7 +228,7 @@ spec:
             logLevel: verbose
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 390742a
+              tag: f161853
         node:
           cleanup:
             image:
@@ -231,7 +238,7 @@ spec:
           driver:
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 390742a
+              tag: f161853
           driverRegistrar:
             image:
               # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
## What

- **Driver image `390742a` → `f161853`** (controller + node) — democratic-csi master with the three merged iscsi wedge fixes from nijave/democratic-csi#30, #31, #32.
- **Enable `node.iscsi.nodeDbSweeper`** in the driver-config ExternalSecret — one-shot startup sweep deleting node-DB records with no active session, scoped to the `ubthv01` basename.

## Background

Recurring node-driver wedge on vmubtkube-a24 (three events Aug 6–15; the Aug 6–7 one was a **2-day total NodeStage outage** ended only by a node reboot). Root cause: concurrent iscsiadm invocations from simultaneous NodeStage/NodeStage bursts convoy on open-iscsi's single exclusive node-DB lock; the driver's 30s exec timeout kills children mid-wait, kubelet retries keep the queue saturated, and the per-volume op-lock turns retries into abort pile-ups. #30 serializes our own invocations (the core fix), #31 absorbs external-holder contention, #32 self-heals the orphaned records those events leave behind (189 accumulated on a24 before last week's manual sweep).

## Deployment notes

- Rolling: Argo will replace controller + all node pods. Expect a brief stage-op pause per node as pods restart; already-staged volumes keep their sessions.
- On startup each node pod now sweeps orphaned node-DB records (after 60s delay) — watch for `iscsi node-db sweep: ... deleted` in driver logs.
- Verification after sync: `csi_sidecar_operations_seconds`/kubelet `csi_operations_seconds` for stage ops, and the driver logs for `(attempt 2/2)` retry lines (should be rare) or queued-command behavior during the nightly volsync window.

Image built with the usual `docker buildx build --pull --push` flow, smoke-tested (`--help`), verified pullable (`skopeo inspect` → `sha256:ca5683f…`).