### PR TITLE
docs: add democratic-csi iscsi convoy memory, refresh perf note

### DIFF
--- a/docs/agent-memory/README.md
+++ b/docs/agent-memory/README.md
@@ -1,6 +1,6 @@
 # Migrated agent knowledge
 
-These notes were migrated from Claude Code project memory. They are historical
+These notes migrated from Claude Code project memory. They are historical
 context, not authority over the current repository. Verify time-sensitive facts
 against the current code and environment.
 
@@ -17,6 +17,7 @@ against the current code and environment.
 - [project argocd secret recreated migration.md](project_argocd_secret_recreated_migration.md)
 - [project calico breaks ll ntp timesyncd.md](project_calico_breaks_ll_ntp_timesyncd.md)
 - [project coredns link local upstream pod netns.md](project_coredns_link_local_upstream_pod_netns.md)
+- [project democratic csi iscsi convoy.md](project_democratic_csi_iscsi_convoy.md)
 - [project democratic csi perf.md](project_democratic_csi_perf.md)
 - [project device udev link info join metric.md](project_device_udev_link_info_join_metric.md)
 - [project gluetun fork.md](project_gluetun_fork.md)

--- a/docs/agent-memory/project_democratic_csi_iscsi_convoy.md
+++ b/docs/agent-memory/project_democratic_csi_iscsi_convoy.md
@@ -1,0 +1,84 @@
+---
+name: democratic-csi-iscsi-convoy
+description: "node-driver iscsiadm idbm-lock convoy wedges (Aug 2026), node-DB record lifecycle, fixes shipped in image f161853"
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: c13d56ad-bf16-4228-befc-93c0791f1819
+---
+
+Investigation 2026-08-14/15 (PRs nijave/democratic-csi#30 #31 #32, deployed
+as image `f161853` via vmubtkube-a PR #428).
+
+## The wedge
+
+Recurring total `NodeStageVolume` outage on the highest-churn node
+(vmubtkube-a24 hosts most volsync churn, ~750-880 stage/unstage/day
+clustered in the nightly ~01:00 window). Three events Aug 6-15:
+
+- Aug 6-7: 21k stage requests / 111 responses, wedged 2 DAYS, fixed only by
+  node reboot (pod restart). Errors: `ABORTED: operation locked due to in
+  progress operation(s)` (per-volume op-lock Set in the bin/ gRPC wrapper —
+  aborts kubelet retries while a handler hangs).
+- Aug 14 23:58-00:56Z (58 min, self-cleared): triggered by the 2f1f691 image
+  rollout coinciding with the volsync wave (~17 concurrent stages); errors
+  `{"code":null,...,"timeout":true}` (driver exec timeout SIGTERMed children).
+
+## Mechanism
+
+- open-iscsi (2.1.9) serializes EVERY node-DB op (reads included) behind one
+  exclusive fcntl lock, `/run/lock/iscsi/iscsi.lock`→`/run/lock/iscsi/lock`,
+  waiters polling ~10ms with ~30s budget; critical section enumerates ALL
+  records, so orphan count directly scales op latency.
+- The driver's iscsiadm runs via the `docker/iscsiadm` wrapper
+  (`chroot /host`), so it takes the HOST's lock and DB — contending with host
+  iscsid too. Container-side iscsiadm reaches host iscsid through the
+  abstract unix socket `@ISCSIADM_ABSTRACT_NAMESPACE` (works because the node
+  pods are hostNetwork; also why in-container probes behave like host ones).
+- Driver has no cross-volume serialization (only the per-volume op-lock), so
+  N volumes x ~9 iscsiadm invocations convoy; driver timeout
+  (`ISCSI_DEFAULT_TIMEOUT`, 30s) kills children exactly as waiters exhaust
+  their budget; kubelet retries keep arrival >= service rate.
+
+## Fixes (all in image f161853)
+
+- #30: module-level async-mutex serializing ALL iscsiadm execs FIFO
+  (src/utils/iscsi.js) — each op runs uncontended; a 17-volume wave drains
+  serially in seconds. Also added the missing child `error` handler (an
+  unsettled spawn used to hang the exec promise forever).
+- #31: bounded retry on `timeout:true` only (`ISCSIADM_TIMEOUT_RETRIES`,
+  default 1, 250ms backoff) — absorbs external-holder contention; non-timeout
+  failures stay fail-fast (actionable stderr).
+- #32: opt-in `node.iscsi.nodeDbSweeper` — one-shot startup sweep (60s delay)
+  deleting node-DB records with no session for the target IQN; scoped by
+  `targetBasename` ("iqn.2025-04.info.somemissing.homelab:ubthv01:").
+  Enabled in the driver-config ExternalSecret in application.democratic-csi.yaml.
+
+First sweep on rollout (2026-08-15): 54 orphans deleted (a20 19, a21 2,
+a22 22, a23 8, a24 3). Verified safe: deleted records were PVs staged on
+OTHER nodes (no local session); re-staging recreates records idempotently.
+
+## Node-DB record lifecycle (reference)
+
+- DB lives at `/etc/iscsi/nodes/<iqn>/<portal>,3260` (hostPath into pods;
+  this open-iscsi build ignores `/var/lib/iscsi`). One record per (PV, node).
+- Created at NodeStage: `-o new`, ~5x `-o update` (CHAP from node-stage
+  secret + timeouts), `-l`; deleted at NodeUnstage: `-u`, `-o delete`, 2
+  verify queries. Records persist across reboots (on-disk); without the
+  sweeper nothing ever removes an orphaned record.
+- Leak sources: driver-pod restart mid-unstage, reboot with volumes staged,
+  unstages lost to wedges. a24 accumulated 189 (Apr-Aug) before the manual
+  sweep; orphans lengthen every future critical section (feedback loop).
+
+## Debugging tricks that worked
+
+- Node pods run privileged with `/host` and hostNetwork: `chroot /host`
+  gives host tools (strace, journalctl); host strace can ptrace the
+  container's children (chroot does not change the pid namespace).
+- `iscsiadm -m session` keeps working when DB ops hang (kernel netlink, no
+  idbm lock) — quick discriminator: DB-lock wedge vs iscsid/iscsi problem.
+- HyperDX (otel.otel_logs, `__hdx_materialized_k8s.node.name` +
+  `pod.name LIKE 'democratic-csi-node%'`): count `new request`/`new response`
+  per NodeStage/Unstage per day — req >> resp = wedge in progress. Only
+  replica chi-hyperdx-replicated-0-0-0 is running as of 2026-08-15.
+- Sweeper results: `rg 'node-db sweep'` in node driver logs.

--- a/docs/agent-memory/project_democratic_csi_perf.md
+++ b/docs/agent-memory/project_democratic_csi_perf.md
@@ -25,10 +25,14 @@ Perf investigation (2026-07-05, PR #214 adds sidecar metrics):
   `csi_sidecar_operations_seconds` (enabled in PR #214) or kubelet
   `csi_operations_seconds` (node ops only, already in Thanos).
 - Blocking snapshots are sanoid `autosnap_*` (syncoid replication) inheriting
-  `democratic-csi:managed_resource=true`. Fix branch (opt-in
-  `zfs.deleteVolumeIgnoreForeignSnapshots`, uses `zfs get -s local,received`):
-  nijave/democratic-csi branch feat/delete-volume-ignore-foreign-snapshots
-  (no PR opened yet; image build + manifest bump still pending).
+  `democratic-csi:managed_resource=true`. RESOLVED: opt-in
+  `zfs.deleteVolumeIgnoreForeignSnapshots` (uses `zfs get -s local,received`)
+  merged in the fork and shipped in driver image 390742a; the config lives in
+  the driver-config ExternalSecret and the Released-PV delete storm cleared.
 - HyperDX ClickHouse: query BOTH replicas (chi-hyperdx-replicated-0-0-0 and
-  -0-1-0) in parallel for throughput; always bound queries with TimestampTime
-  and max_execution_time — unbounded map-key predicates run for minutes.
+  -0-1-0) in parallel for throughput (as of 2026-08-15 only 0-0-0 runs);
+  always bound queries with TimestampTime and max_execution_time —
+  unbounded map-key predicates run for minutes.
+- Follow-up (2026-08-15): the node-side iscsiadm idbm-lock convoy wedge and
+  node-DB record lifecycle live in project_democratic_csi_iscsi_convoy.md;
+  both perf fixes and the convoy fixes ship in image f161853.


### PR DESCRIPTION
Docs-only follow-up to #428 / the Aug 2026 wedge investigation.

- **New** `project_democratic_csi_iscsi_convoy.md`: the idbm-lock convoy mechanism (host lock via the chroot wrapper, exclusive locking of every node-DB op, orphan-count-scaled critical sections), the three wedge events (Aug 6–7 two-day, Aug 8 reboot, Aug 14 58-min), node-DB record lifecycle and leak sources, the three fixes now live in image `f161853` with first-sweep numbers (54 orphans), and the debugging techniques that cracked it (chroot `/host` tooling, `-m session` as the no-lock discriminator, HyperDX request/response pairing).
- **Refresh** `project_democratic_csi_perf.md`: foreign-snapshots fix marked resolved (shipped in `390742a`, delete storm cleared), only HyperDX replica `0-0-0` currently runs, cross-link to the new note.
- **README**: index entry for the new file, plus one passive-voice fix the prose lint flagged on touch.