### PR TITLE
chore(deps): update democratic-csi fork image to 3c97535

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -228,7 +228,7 @@ spec:
             logLevel: verbose
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: f161853
+              tag: 3c97535
         node:
           cleanup:
             image:
@@ -238,7 +238,7 @@ spec:
           driver:
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: f161853
+              tag: 3c97535
           driverRegistrar:
             image:
               # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
Bumps the democratic-csi fork driver image f161853 -> 3c97535 (controller + node).

Built from nijave/democratic-csi master @ 3c97535 after merging the fork-review fixes (nijave/democratic-csi#44 through nijave/democratic-csi#54, closing issues #33-#43 there). Highlights relevant to vmubtkube-a:

- **NodeUnstageVolume iscsiadm gate** (fixes a regression from the unstage rework): non-iSCSI volumes no longer hard-fail unstage when iscsiadm is unusable; iSCSI volumes keep fail-fast reclaim behavior.
- **SIGKILL escalation for stuck iscsiadm** (`ISCSIADM_KILL_GRACE_MS`, default 10s after exec timeout): a SIGTERM-ignoring child can no longer wedge the node-wide iscsiadm exec mutex.
- **Node-DB sweeper race fix**: per-record existence + session re-check immediately before delete, so a concurrent NodeStage login can't lose its fresh record during the startup sweep.
- **multipath/zfs/zpool wrappers now exec** the real tool (same zombie-orphan fix as mount/umount/iscsiadm); multipath wrapper previously swallowed exit codes (always 0).
- **Shell-escaping hardening**: local + ssh exec clients escape per-arg; Zetabyte contract inverted (callers raw, executors escape); TrueNAS SCALE SCST resize regression fixed.
- Plus: k8s client ESM engines fix, eslint correctness rules enforced in CI, nvmet namespace subsystem verification.

Image pushed: `registry.apps.nickv.me/democratic-csi/democratic-csi:3c97535` (from `docker buildx build --pull --push` on fork master).

131/131 unit tests pass on the merged tree; lint 0 errors.