### PR TITLE
chore(deps): update democratic-csi fork image to 8650e83

### DIFF
--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -228,7 +228,7 @@ spec:
             logLevel: verbose
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 3c97535
+              tag: 8650e83
         node:
           cleanup:
             image:
@@ -238,7 +238,7 @@ spec:
           driver:
             image:
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 3c97535
+              tag: 8650e83
           driverRegistrar:
             image:
               # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
Reconciles the deployed democratic-csi image with the rewritten fork master.

## Why
After the destructive rebase of `nijave/democratic-csi` into atomic, upstream-PR-able commits, the previously-deployed tag `3c97535` (merge of PR #54) is **no longer reachable from `origin/master`** — it survives only on `backup/master-3c97535`. `8650e83` is the current master HEAD.

## What's in the image
Functionally **identical** to `3c97535`: the only source difference between the two commits is comment/blank-line removals (**0 non-comment diff lines**). This is a provenance/traceability update, not a behavior change — the running image can now be reproduced from a plain master checkout.

## Verification
- Built from clean `8650e83` checkout: `registry.apps.nickv.me/democratic-csi/democratic-csi:8650e83` (digest `sha256:7ae8b71769c7eb37fad3dd99c7b016db59ce95bd3b635231b4afb8eec38e7c7b`)
- Cluster state at time of change: 60/60 PV+PVC Bound, 45 VolumeAttachments healthy, node iSCSI sessions == node-DB on all 5 nodes, backend zvols/targets 1:1 with PVs.