### PR TITLE
fix(otel-collector): keep Omada [client:MAC] out of RFC 5424 SD field

### DIFF
--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -130,9 +130,14 @@ spec:
                 # SD-ELEMENT is optional: TP-Link Omada Controller-level events
                 # (e.g. "log storage limit reached") omit it entirely and put
                 # bare message text where the SD field would be.
+                # The SD capture only matches a bare "-" or a real SD-ELEMENT
+                # (a bracket containing key=value params). Omada application
+                # events begin the message with a bracket like [client:MAC] /
+                # [ap:MAC] that contains no "=", so it is left in the message
+                # instead of being swallowed as STRUCTURED-DATA.
                 - type: regex_parser
                   if: 'body matches "^<\\d+>\\d\\s"'
-                  regex: '^<(?P<pri>\d+)>(?P<version>\d)\s+(?P<time>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<host>\S+)\s+(?P<app>\S+)\s+(?P<proc>\S+)\s+(?P<msgid>\S+)(?:\s+(?P<sd>\[[^\]]*\]|-))?\s*(?P<message>.*)$'
+                  regex: '^<(?P<pri>\d+)>(?P<version>\d)\s+(?P<time>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<host>\S+)\s+(?P<app>\S+)\s+(?P<proc>\S+)\s+(?P<msgid>\S+)(?:\s+(?P<sd>-|\[[^\]]*=[^\]]*\]))?\s*(?P<message>.*)$'
                   parse_from: body
                   parse_to: attributes
                   on_error: send
@@ -147,6 +152,18 @@ spec:
                 - type: regex_parser
                   if: 'body matches "^\\["'
                   regex: '^\[(?P<time>\d+(?:\.\d+)?)\]\s*(?P<message>.*)$'
+                  parse_from: body
+                  parse_to: attributes
+                  on_error: send
+                # Omada Controllers embed [client:MAC] in the message body, not
+                # in RFC 5424 STRUCTURED-DATA. Pull the client MAC straight from
+                # the raw line into its own attribute so MAC lookups never depend
+                # on the header field split (which drifts when the controller or
+                # site name contains a space). Queryable as
+                # LogAttributes['client_mac'].
+                - type: regex_parser
+                  if: 'body matches "client:"'
+                  regex: 'client:(?P<client_mac>[^\]]+)'
                   parse_from: body
                   parse_to: attributes
                   on_error: send


### PR DESCRIPTION
## Problem

The syslog RFC 5424 parser in `application.otel-collector.yaml` loses the client MAC from TP-Link Omada roam/online/offline events.

Omada lines put the client identifier at the **start of the message** as `[client:56-20-FC-48-16-8C] is roaming from [ap:…]…`. Omada does **not** emit a real RFC 5424 STRUCTURED-DATA element, but the parser's optional SD capture matched *any* bracketed token:

```
(?:\s+(?P<sd>\[[^\]]*\]|-))?
```

so it swallowed the leading `[client:…]` into the `sd` field, and `LogAttributes['message']` came out without the MAC. Because it hinges on header field alignment, the behaviour was fragile: the site rename that put a **space** in the controller hostname (`… 1315 Dennison`) shifted the single-token `HOSTNAME` capture and accidentally spared the client token. Every roam row before the rename lost its MAC and was recoverable only from the raw `Body` column.

## Fix

1. **Tighten the SD capture** to a bare `-` or a real SD-ELEMENT (a bracket containing `key=value` params). Omada's `[client:MAC]`/`[ap:MAC]` tokens contain no `=`, so they now stay in the message; a genuine RFC 5424 SD element is still captured.
2. **Add a dedicated extractor** that pulls the MAC from the raw body into `LogAttributes['client_mac']`, so MAC lookups no longer depend on the header split (which also misparses `host`/`app` when the controller/site name contains a space).

Both changes are in the anchored `&syslog_ops` block, so they apply to both the UDP and TCP syslog receivers.

## Verification

- `yaml.safe_load_all` parses; pre-commit `kubeconform` / `pluto` / helm-render all pass.
- Regex tested against three cases:
  - Omada roam line (single-word host, the previously-mangled case) → `[client:…]` stays in `message`; `client_mac` = `56-20-FC-48-16-8C`.
  - Genuine RFC 5424 SD element `[exampleSDID@32473 iut="3"]` → still captured as `sd` (backward compatible).
  - Controller event with bare `-` SD → parses.

## Scope / rollout

Affects **newly-ingested** rows only; historical mangled rows stay queryable via `Body`. Out of scope: the RFC 5424 `HOSTNAME`-with-space misparse of `host`/`app` fields (Omada violates the spec by putting a space in HOSTNAME); the new `client_mac` extractor sidesteps it for the query use case.