### PR TITLE
docs: fix renovate-release-api bootstrap comment after in-tree digest pin

### DIFF
--- a/renovate-release-api.yaml
+++ b/renovate-release-api.yaml
@@ -7,9 +7,10 @@
 #
 # Its own image ships fully wired in this PR: customDatasources +
 # packageRule in renovate.json, annotation on the image line below.
-# Bootstrap is a brief unpinned :latest; once the service is live, the
-# hosted app's first run opens the latest@sha256:… pin PR, and Renovate
-# queries the running service for its own updates from then on.
+# The bootstrap digest is pinned in-tree to the first published build
+# (68581811); from the first hosted-app run after this deploys, Renovate
+# queries the running service and re-pins latest@sha256:… on every later
+# CI build.
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Follow-up to #441: the merged manifest pins the bootstrap digest in-tree (`latest@sha256:b8b7cf8a…ae97`, `imagePullPolicy: IfNotPresent`), but the header comment still describes the abandoned unpinned-`:latest` bootstrap where the hosted app's first run would open the pin PR. No pin PR is coming — only digest re-pins from later CI builds. Comment-only; no spec change.