### PR TITLE
feat: wire self-built images to the renovate-release-api custom datasource

### DIFF
--- a/.ci/mirror-images.sh
+++ b/.ci/mirror-images.sh
@@ -92,6 +92,19 @@ done > "$OVERRIDES"
 
 jq -r '.ignoreDeps[]? // empty' "$RENOVATE_FILE" > "$IGNORE"
 
+# Deps annotated datasource=custom.* (the internal renovate-release-api
+# datasource) are locally built: their mirror paths have no upstream to
+# mirror from, and the tags Renovate bumps never exist upstream. Same
+# annotation source as the registryUrl overrides above, feeding the same
+# ignore list ignoreDeps used to (docs/renovate-private-registry-datasource-
+# design.md "Mirror-script interaction").
+{ git grep -h -E '#[[:space:]]*renovate:.*datasource=custom\.' -- '*.yaml' '*.yml' || true; } \
+  | awk '{
+      name = ""
+      for (i = 1; i <= NF; i++) if ($i ~ /^depName=/) name = substr($i, 9)
+      if (name != "") print name
+    }' | sort -u >> "$IGNORE"
+
 # Pick a diff base appropriate for the trigger, then mirror refs found on
 # added lines only. Re-runs against the same base are idempotent (regctl copy
 # no-ops when digests match).

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@ that encode repo conventions an agent might not infer, enforced before merge.
 - Outcome: adopt/skip decision; if adopt, wire into the CI validation steps
   and pre-commit like the kubeconform checks.
 
-## 3. Custom Renovate version API for private-registry images
+## 3. Custom Renovate version API for private-registry images — RESOLVED 2026-08-16
 
 Self-built images (`cukk`, `python-envoy-authz`, `cpu-benchmark`,
 `qdirstat-cache-writer`, forked `gluetun`) sit in `renovate.json`
@@ -60,6 +60,26 @@ docker-datasource hostRules.
   `cukk.yaml` (node-upgrade operator, cluster-wide node/eviction RBAC),
   `python-envoy-authz.yaml` (Contour ext-authz path), `cpu-benchmark.yaml`,
   `qds.yaml` (untracked).
+
+Resolved by the `renovate-release-api` deployment (PR #441, design doc
+`docs/renovate-private-registry-datasource-design.md`): a Go service in
+github.com/nijave/renovate-release-api exposed publicly at
+`renovate-releases.apps.somemissing.info`, serving `/v1/releases/{repo}`
+with per-tag digests and build timestamps. The wiring PR removed every
+populated `ignoreDeps` entry, added per-image packageRules (latest-tracked
+with `pinDigests` for cukk, python-envoy-authz, cpu-benchmark,
+democratic-csi, and renovate-release-api itself; `^v` semver for the
+jellyfin fork; plain semver for homelab-pki) plus annotations on each
+image line. democratic-csi joined the set beyond the original six: hex
+SHAs never order, so latest-tracking is the only flow that yields updates;
+the bootstrap copied `146445b` to `latest`, and its CI must keep publishing
+`latest`. Digest pinning — the formerly blocked tail — now
+arrives as Renovate `pinDigest` PRs, which also flip each workload's
+`imagePullPolicy` to `IfNotPresent`. Remaining when their manifests land
+in git: `qds.yaml` (qdirstat-cache-writer) and the forked
+`qdm12/gluetun`. The mirror script now skips lines annotated
+`datasource=custom.` (replacing the ignoreDeps skip list), and blackbox
+probes assert a 200 with a non-empty releases array per tracked image.
 
 ## 4. Custom Renovate version API for the VectorChord CNPG image — RESOLVED 2026-08-14
 

--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -85,6 +85,36 @@ spec:
             - name: web.apps.somemissing.info
               url: https://web.apps.somemissing.info
               module: http_2xx
+            # renovate-releases: one probe per Renovate-tracked self-built
+            # image (see docs/renovate-private-registry-datasource-design.md
+            # "Silent freeze"). Catches TLS/routing failures at the public
+            # edge that the service's own /healthz ServiceMonitor can't see.
+            # 60s, not the 10s default: each probe makes the service walk the
+            # repo's full tag list.
+            - name: renovate-releases-cukk
+              url: https://renovate-releases.apps.somemissing.info/v1/releases/nijave/cukk
+              module: renovate_releases_2xx
+              interval: 60s
+            - name: renovate-releases-python-envoy-authz
+              url: https://renovate-releases.apps.somemissing.info/v1/releases/nijave/python-envoy-authz
+              module: renovate_releases_2xx
+              interval: 60s
+            - name: renovate-releases-cpu-benchmark
+              url: https://renovate-releases.apps.somemissing.info/v1/releases/cpu-benchmark
+              module: renovate_releases_2xx
+              interval: 60s
+            - name: renovate-releases-homelab-pki
+              url: https://renovate-releases.apps.somemissing.info/v1/releases/nijave/homelab-pki
+              module: renovate_releases_2xx
+              interval: 60s
+            - name: renovate-releases-jellyfin
+              url: https://renovate-releases.apps.somemissing.info/v1/releases/jellyfin
+              module: renovate_releases_2xx
+              interval: 60s
+            - name: renovate-releases-democratic-csi
+              url: https://renovate-releases.apps.somemissing.info/v1/releases/democratic-csi/democratic-csi
+              module: renovate_releases_2xx
+              interval: 60s
         verticalPodAutoscaler:
           enabled: true
         configReloader:
@@ -155,6 +185,15 @@ spec:
               prober: http
               http:
                 preferred_ip_protocol: "ip4"
+            # renovate-releases custom datasource: 200 alone is not enough —
+            # the probe asserts a non-empty releases array, so it also fires
+            # when the service answers 200 with no data (registry path wedged).
+            renovate_releases_2xx:
+              prober: http
+              http:
+                preferred_ip_protocol: "ip4"
+                fail_if_body_not_matches_regexp:
+                  - '"releases":\[[^\]]'
             http_post_2xx:
               prober: http
               http:

--- a/application.democratic-csi.yaml
+++ b/application.democratic-csi.yaml
@@ -227,8 +227,9 @@ spec:
           driver:
             logLevel: verbose
             image:
+              # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/democratic-csi/democratic-csi
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 146445b
+              tag: latest
         node:
           cleanup:
             image:
@@ -237,8 +238,9 @@ spec:
               tag: 1.38.0
           driver:
             image:
+              # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/democratic-csi/democratic-csi
               registry: registry.apps.nickv.me/democratic-csi/democratic-csi
-              tag: 146445b
+              tag: latest
           driverRegistrar:
             image:
               # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar

--- a/cpu-benchmark.yaml
+++ b/cpu-benchmark.yaml
@@ -21,6 +21,7 @@ spec:
       - operator: Exists
       containers:
       - name: benchmark
+        # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/cpu-benchmark
         image: registry.apps.nickv.me/cpu-benchmark:latest
         command: ["/bin/bash", "-c"]
         args:

--- a/cukk.yaml
+++ b/cukk.yaml
@@ -30,6 +30,7 @@ spec:
       serviceAccountName: cukk
       containers:
         - name: operator
+          # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/nijave/cukk
           image: registry.apps.nickv.me/nijave/cukk:latest
           imagePullPolicy: Always
           ports:

--- a/docs/renovate-private-registry-datasource-design.md
+++ b/docs/renovate-private-registry-datasource-design.md
@@ -333,3 +333,46 @@ order hex tags.
   repo vs. in the cukk-style source repo), decided at implementation.
 - Open: whether `qdirstat-cache-writer`'s manifest (`qds.yaml`, still
   untracked) ever lands; the wiring is ready if it does.
+
+## Implementation status (2026-08-16)
+
+Deployed and wired; see `TODO.md` item 3 for the summary and PR trail.
+How it landed, including deviations from the sketch above:
+
+- **Service**: Go (standard library only) in
+  github.com/nijave/renovate-release-api, Woodpecker-built via the shared
+  buildkitd with a Dockerfile, pushed as
+  `registry.apps.nickv.me/nijave/renovate-release-api` (not the sketch's
+  `nijave/renovate-datasource` — the source repo's name won). Manifest:
+  `renovate-release-api.yaml`. It fetches manifests by GET rather than
+  HEAD — one round trip carries both `Docker-Content-Digest` and the
+  config reference — and resolves `tags.latest` exactly as specified.
+  Verified live against the real registry before rollout (the cukk
+  payload reproduced the digests above byte-for-byte).
+- **No bootstrap paradox**: the service's own image carries the
+  `datasource=custom.private-registry` annotation and packageRule from
+  day one — one hand-pinned digest at bootstrap, then Renovate queries
+  the running service for its own updates. No `ignoreDeps` entry at all;
+  the "permanently untracked" risk above did not survive contact.
+- **Wiring granularity**: one PR for all images, not one-per-PR (the
+  maintainer accepted the coarser revert granularity). Beyond the six images here,
+  `democratic-csi/democratic-csi` joined the set: hex-only tags, so the
+  bootstrap copied `146445b` to a `latest` tag and its CI must keep
+  publishing `latest` for updates to flow.
+- **customManagers**: the multiline `registry:`/`repository:`+`tag:`
+  matchStrings gained an optional `@(?<currentDigest>sha256:…)` group so
+  `pinDigests` round-trips in the valuesObject form (democratic-csi's
+  shape); without it a pinned `tag: latest@sha256:…` would poison the
+  dep on the next run.
+- **Response shape**: the response omits `homepage` — the registry
+  exposes no source for it and Renovate's schema does not require it.
+- **Mirror script**: `.ci/mirror-images.sh` now skips refs whose dep is
+  annotated `datasource=custom.`, replacing the emptied `ignoreDeps`
+  skip list ("if it gets tiresome" — it never got tiresome, it just
+  became necessary).
+- **Blackbox probes**: `renovate_releases_2xx` module asserts a 200 with
+  a non-empty `releases` array; one probe per tracked image at 60s
+  (each probe walks the repo's full tag list, so not the 10s default),
+  alert `RenovateReleasesEndpointFailing` at two consecutive failures.
+- **Still open**: `qds.yaml` (qdirstat-cache-writer) and the forked
+  `qdm12/gluetun` manifest; the wiring is ready when they land.

--- a/homelab-pki.yaml
+++ b/homelab-pki.yaml
@@ -128,6 +128,7 @@ spec:
       serviceAccountName: pki-reconciler
       containers:
         - name: reconcile
+          # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/nijave/homelab-pki
           image: registry.apps.nickv.me/nijave/homelab-pki:0.2.5
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
@@ -163,6 +164,7 @@ spec:
           serviceAccountName: pki-reconciler
           containers:
             - name: reconcile
+              # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/nijave/homelab-pki
               image: registry.apps.nickv.me/nijave/homelab-pki:0.2.5
               imagePullPolicy: Always
               command: ["/bin/sh", "-c"]

--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -164,6 +164,7 @@ spec:
         runAsGroup: 1001
       containers:
       - name: jellyfin
+        # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/jellyfin
         image: registry.apps.nickv.me/jellyfin:v10.11.5-nv-hdr-patch
         # command: [sleep, infinity]
         env:

--- a/python-envoy-authz.yaml
+++ b/python-envoy-authz.yaml
@@ -101,6 +101,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: python-envoy-authz
+        # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/nijave/python-envoy-authz
         image: registry.apps.nickv.me/nijave/python-envoy-authz:latest
         imagePullPolicy: Always
         resources:

--- a/renovate-release-api.yaml
+++ b/renovate-release-api.yaml
@@ -238,3 +238,36 @@ spec:
       for: 30m
       labels:
         severity: warning
+---
+# Blackbox probes of the real public endpoint (targets in
+# application.blackbox-exporter.yaml, module renovate_releases_2xx): 200
+# plus a non-empty releases array per tracked image. These catch
+# TLS/routing/edge failures the /healthz ServiceMonitor above cannot see;
+# the module label is unique to these probes, so no job-name guessing.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: renovate-releases-blackbox
+  namespace: default
+  labels:
+    release: prom
+spec:
+  groups:
+  - name: renovate-releases
+    rules:
+    - alert: RenovateReleasesEndpointFailing
+      annotations:
+        summary: A renovate-releases blackbox probe is failing.
+        description: >-
+          probe_success == 0 for two consecutive 60s scrapes of
+          https://renovate-releases.apps.somemissing.info/v1/releases/<repo>.
+          The module asserts a 200 with a non-empty releases array, so this
+          fires both on edge/TLS/routing breakage and on the service
+          answering empty — either silently freezes Renovate updates for
+          self-built images (the "Silent freeze" risk in
+          docs/renovate-private-registry-datasource-design.md). Check the
+          endpoint by hand, then the deployment and RenovateReleaseApiDown.
+      expr: 'probe_success{module="renovate_releases_2xx"} == 0'
+      for: 2m
+      labels:
+        severity: warning

--- a/renovate.json
+++ b/renovate.json
@@ -35,20 +35,14 @@
       "format": "json"
     }
   },
-  "ignoreDeps": [
-    "registry.apps.nickv.me/jellyfin",
-    "registry.apps.nickv.me/nijave/cukk",
-    "registry.apps.nickv.me/nijave/python-envoy-authz",
-    "registry.apps.nickv.me/nijave/homelab-pki"
-  ],
   "customManagers": [
     {
       "customType": "regex",
       "managerFilePatterns": ["/\\.yaml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s+\\S+?:\\s*\\S+?:(?<currentValue>[^@\\s\"']+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
-        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*registry:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?",
-        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*repository:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?",
+        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*registry:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?",
+        "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*repository:\\s*\\S+\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?",
         "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*version:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{datasource}}{{else}}docker{{/if}}"
@@ -222,6 +216,46 @@
       "matchPackageNames": ["registry.apps.nickv.me/nijave/renovate-release-api"],
       "pinDigests": true,
       "versioning": "regex:^(?<major>latest)$"
+    },
+    {
+      "description": "cukk: self-built; latest = newest CI build of the default branch, tracked by digest (docs/renovate-private-registry-datasource-design.md)",
+      "matchPackageNames": ["registry.apps.nickv.me/nijave/cukk"],
+      "pinDigests": true,
+      "versioning": "regex:^(?<major>latest)$"
+    },
+    {
+      "description": "python-envoy-authz: self-built; latest = newest CI build of the default branch, tracked by digest",
+      "matchPackageNames": ["registry.apps.nickv.me/nijave/python-envoy-authz"],
+      "pinDigests": true,
+      "versioning": "regex:^(?<major>latest)$"
+    },
+    {
+      "description": "cpu-benchmark: self-built, rebuilt by hand rarely; latest is the only tag, tracked by digest",
+      "matchPackageNames": ["registry.apps.nickv.me/cpu-benchmark"],
+      "pinDigests": true,
+      "versioning": "regex:^(?<major>latest)$"
+    },
+    {
+      "description": "democratic-csi driver: self-built fork; latest = newest CI build, tracked by digest — hex commit tags ride along as releases but never order. The latest tag was bootstrapped by copying 146445b; the CI push list must keep publishing latest.",
+      "matchPackageNames": ["registry.apps.nickv.me/democratic-csi/democratic-csi"],
+      "pinDigests": true,
+      "versioning": "regex:^(?<major>latest)$"
+    },
+    {
+      "description": "jellyfin: self-built fork tags vMAJOR.MINOR.PATCH-suffix. The ^v anchor filters the unprefixed junk tags; the suffix must NOT be a (?<compatibility>) capture — that splits tag lines and suppresses updates (the selfoss trap; docs/renovate-private-registry-datasource-design.md)",
+      "matchPackageNames": ["registry.apps.nickv.me/jellyfin"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-\\S+$"
+    },
+    {
+      "description": "homelab-pki: self-built semver tags; tftest never passes the service's tag filter",
+      "matchPackageNames": ["registry.apps.nickv.me/nijave/homelab-pki"],
+      "versioning": "semver"
+    },
+    {
+      "description": "jellyfin.yaml and python-envoy-authz.yaml are also scanned by the kubernetes manager, where registryAliases maps the mirror host to Docker Hub — these self-built repos don't exist there. The regex-manager annotation (custom datasource) owns them; disable the broken duplicate dep (thanos pattern).",
+      "matchManagers": ["kubernetes"],
+      "matchPackageNames": ["**/jellyfin", "**/nijave/python-envoy-authz"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

Completes the design's rollout (`docs/renovate-private-registry-datasource-design.md`, deployed in #441): every internally-published image is now Renovate-tracked through `renovate-releases.apps.somemissing.info`. Mirrored upstream images (thanos, busybox, the csi sidecars, …) keep their existing docker-datasource wiring — only self-built repos change.

- **renovate.json** — `ignoreDeps` is now empty and removed. Per-image packageRules: latest-tracked with `pinDigests` (cukk, python-envoy-authz, cpu-benchmark, democratic-csi driver), `^v`-anchored regex for the jellyfin fork tags (suffix deliberately not a `compatibility` capture), plain semver for homelab-pki; kubernetes-manager duplicate-dep disables for jellyfin + python-envoy-authz (thanos pattern). The multiline `registry:`/`tag:` matchStrings gain an optional `currentDigest` group so `pinDigests` round-trips in the valuesObject form.
- **Manifests** — `datasource=custom.private-registry` annotations on every image line (both homelab-pki reconcile sites, both democratic-csi driver sites). **democratic-csi** moves `146445b` → `latest`: hex-only tags never order, so latest-tracking is the only flow that yields updates. The `latest` tag was bootstrapped in the registry by copying `146445b` (digest-verified); **its CI must add `latest` to the push list** to keep updates flowing.
- **`.ci/mirror-images.sh`** — skips refs whose dep is annotated `datasource=custom.`, replacing the emptied `ignoreDeps` skip list (the design's own suggestion), so locally-built paths are never probed against Docker Hub.
- **Blackbox probes** — `renovate_releases_2xx` module asserts 200 **and** a non-empty `releases` body; one target per tracked image at 60s (each probe walks the repo's full tag list); `RenovateReleasesEndpointFailing` alert on two consecutive failures.
- **Docs** — TODO item 3 resolved; design doc gains an implementation-status section.

## Verification

- Live endpoint: all six deps resolve with every manifest's current tag present in `releases`; `tags.latest` resolves for cukk/python-envoy-authz/democratic-csi.
- matchStrings tested against the single-line, valuesObject, and pinned-digest (`tag: latest@sha256:…`) forms.
- kubeconform + pluto via pre-commit (first attempt caught a broken indent in homelab-pki.yaml — fixed before commit).