### PR TITLE
fix: set external-dns policy, rename axfr flag

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -95,6 +95,7 @@ spec:
                 name: rfc2136-tsig-secret
                 key: tsig-secret
         args:
+        - --policy=sync
         - --registry=txt
         - --txt-prefix=external-dns-
         - --txt-owner-id=k8s
@@ -108,7 +109,7 @@ spec:
         - --rfc2136-tsig-secret-alg=hmac-sha256
         - --rfc2136-tsig-keyname=external-dns
         - --rfc2136-tsig-secret=$(TSIG_SECRET)
-        - --rfc2136-tsig-axfr
+        - --rfc2136-axfr
         - --source=service
         - --source=ingress
         - --source=contour-httpproxy


### PR DESCRIPTION
external-dns v0.22 (renovate bump in d94d0f7) crash-loops on startup:

- `config validation failed: --policy must be set explicitly` — v0.22
  removed the implicit default rather than swap it
  ([05f0be7](https://github.com/kubernetes-sigs/external-dns/commit/05f0be7f17f37312d502c9c743dbc59566df11ab)).
  The old implicit default was **sync**, so `--policy=sync` restores the
  pre-upgrade behavior exactly.
- `--rfc2136-tsig-axfr` deprecated → `--rfc2136-axfr`. Pure rename, no
  behavior change
  ([#6598](https://github.com/kubernetes-sigs/external-dns/pull/6598)).

## Why sync won't delete anything important

Audited live DNS (unauthenticated TXT reads + kubectl) before choosing
sync over upsert-only:

- With `--registry=txt --txt-owner-id=k8s`, sync can only delete
  A/AAAA/CNAME records inside the two domain-filtered zones that carry
  an `external-dns-<host>` TXT owned by `k8s`.
- All 9 owned records (argocd/contour/grafana/hyperdx/jellyfin/
  otel-collector/prometheus/prom-remote-write in `k8s.*`, immich in
  `apps.*`) map to live sources.
- The other in-zone records (arr stack, searxng, mumble, syslog,
  vikunja, and the manual apps.* CNAMEs to contour.k8s) have no
  heritage TXT at either the bare or prefixed name, so they're
  invisible to deletion. They've coexisted with the old implicit sync
  for months and still match live ClusterIPs.
- Out-of-scope names (minecraft.somemissing.info, rss.nickv.me, zone
  apex, webhooks.somemissing.info) are outside the domain filters.

Every desired hostname already has a record, so the first run after
merge creates and deletes nothing — it only resumes normal
reconciliation.