### PR TITLE
fix: pin external-dns legacy annotation prefix

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -96,6 +96,7 @@ spec:
                 key: tsig-secret
         args:
         - --policy=sync
+        - --annotation-prefix=external-dns.alpha.kubernetes.io/
         - --registry=txt
         - --txt-prefix=external-dns-
         - --txt-owner-id=k8s


### PR DESCRIPTION
v0.22 switched the default annotation prefix from
`external-dns.alpha.kubernetes.io/` to the GA `external-dns.kubernetes.io/`
([#6424](https://github.com/kubernetes-sigs/external-dns/pull/6424)).
All 18 services in this repo annotate with the legacy alpha
`/hostname` key, so after #459 restored `--policy=sync`, the first run
found an **empty service-sourced desired set and deleted every
service-sourced record it owned** — ~35 RRs across both local zones
(sonarr/radarr/prowlarr/sabnzbd/jellyfin/searxng/mumble/vikunja/
syslog/woodpecker/agents-otel/prometheus/prom-remote-write/grafana/
hyperdx/argocd.k8s/otel-collector/contour A records, plus their
registry TXTs). The `apps.*` CNAMEs to `contour.k8s.somemissing.info`
now dangle through the deleted target.

This pins the alpha prefix explicitly — the migration escape hatch
documented in #6424 itself. Upstream later added a startup guard for
exactly this silent-deletion mode
([adeae1d](https://github.com/kubernetes-sigs/external-dns/commit/adeae1d08b38716122c3ca6f9135abf27fd4c3cd)),
but v0.22.0 predates it.

**Recovery is automatic**: once this merges, the next 1m interval
recreates all deleted A records from the (restored) desired set. No
manual DNS repair needed.

Optional follow-up: migrate the 18 annotations to the GA prefix and
drop this flag.