### PR TITLE
chore: stage GA external-dns annotations beside alpha

### DIFF
--- a/application.argocd.yaml
+++ b/application.argocd.yaml
@@ -217,3 +217,4 @@ spec:
           service:
             annotations:
               external-dns.alpha.kubernetes.io/hostname: argocd.k8s.somemissing.info
+              external-dns.kubernetes.io/hostname: argocd.k8s.somemissing.info

--- a/application.hyperdx.yaml
+++ b/application.hyperdx.yaml
@@ -80,6 +80,7 @@ metadata:
   namespace: hyperdx
   annotations:
     external-dns.alpha.kubernetes.io/hostname: hyperdx.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: hyperdx.k8s.somemissing.info
 spec:
   type: ClusterIP
   ports:

--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -52,6 +52,7 @@ spec:
             appProtocol: https
             annotations:
               external-dns.alpha.kubernetes.io/hostname: grafana.k8s.somemissing.info
+              external-dns.kubernetes.io/hostname: grafana.k8s.somemissing.info
           serviceMonitor:
             interval: 30s
             scheme: https
@@ -244,6 +245,7 @@ spec:
           service:
             annotations:
               external-dns.alpha.kubernetes.io/hostname: prometheus.k8s.somemissing.info
+              external-dns.kubernetes.io/hostname: prometheus.k8s.somemissing.info
           prometheusSpec:
             replicas: 2
             # `hard` = requiredDuringScheduling on hostname; with 8 nodes and 2

--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -268,6 +268,7 @@ spec:
         service:
           annotations:
             external-dns.alpha.kubernetes.io/hostname: otel-collector.k8s.somemissing.info
+            external-dns.kubernetes.io/hostname: otel-collector.k8s.somemissing.info
 
         serviceMonitor:
           enabled: true
@@ -306,6 +307,7 @@ metadata:
   namespace: monitoring
   annotations:
     external-dns.alpha.kubernetes.io/hostname: syslog.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: syslog.k8s.somemissing.info
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/application.vikunja.yaml
+++ b/application.vikunja.yaml
@@ -64,6 +64,7 @@ spec:
               # public URL needs no port suffix.
               annotations:
                 external-dns.alpha.kubernetes.io/hostname: vikunja.k8s.somemissing.info
+                external-dns.kubernetes.io/hostname: vikunja.k8s.somemissing.info
               ports:
                 http:
                   port: 80

--- a/docs/agent-memory/project_serviceip_routable.md
+++ b/docs/agent-memory/project_serviceip_routable.md
@@ -9,3 +9,10 @@ In this cluster, the Kubernetes Service network is routable from outside the clu
 **Why:** The cluster's Service CIDR is routable on the surrounding network, so LoadBalancer/Ingress isn't needed for L4 exposure. Many existing services (e.g. `sonarr.yaml`, `prowlarr.yaml`, `application.otel-collector.yaml`) already use this pattern.
 
 **How to apply:** When the user asks to "expose" a Service externally, default to ClusterIP + `external-dns.alpha.kubernetes.io/hostname` annotation. Do not propose LoadBalancer, NodePort, or Ingress/HTTPProxy unless the user specifically wants L7 features (TLS termination, host/path routing, auth) — and even then, ask first.
+
+**Caveat (2026-08-20):** external-dns v0.22 changed its default annotation
+prefix to the GA `external-dns.kubernetes.io/`, so the deployment must pin
+`--annotation-prefix=external-dns.alpha.kubernetes.io/` so external-dns reads
+these annotations. Without the flag the service source produces an empty desired set
+and `--policy=sync` deletes every service-sourced record it owns (incident:
+~35 records purged on the v0.22 upgrade, PR #460 restored the prefix).

--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -120,6 +120,7 @@ metadata:
   namespace: media
   annotations:
     external-dns.alpha.kubernetes.io/hostname: jellyfin.apps.somemissing.info
+    external-dns.kubernetes.io/hostname: jellyfin.apps.somemissing.info
   labels:
     app.kubernetes.io/component: jellyfin-server
     app.kubernetes.io/name: jellyfin

--- a/mumble.yaml
+++ b/mumble.yaml
@@ -96,6 +96,7 @@ metadata:
   namespace: default
   annotations:
     external-dns.alpha.kubernetes.io/hostname: mumble.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: mumble.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: mumble-server
     app.kubernetes.io/name: mumble

--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -213,6 +213,7 @@ metadata:
     # the gateway over BGP), so a plain ClusterIP plus this annotation is all an
     # agent outside the cluster needs -- see "DNS zones and TLS" in README.md.
     external-dns.alpha.kubernetes.io/hostname: agents-otel.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: agents-otel.k8s.somemissing.info
 spec:
   type: ClusterIP
   selector:

--- a/prowlarr.yaml
+++ b/prowlarr.yaml
@@ -113,6 +113,7 @@ metadata:
   namespace: media
   annotations:
     external-dns.alpha.kubernetes.io/hostname: prowlarr.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: prowlarr.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: prowlarr
     app.kubernetes.io/name: arr

--- a/radarr.yaml
+++ b/radarr.yaml
@@ -113,6 +113,7 @@ metadata:
   namespace: media
   annotations:
     external-dns.alpha.kubernetes.io/hostname: radarr.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: radarr.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: radarr
     app.kubernetes.io/name: arr

--- a/sabnzbd.yaml
+++ b/sabnzbd.yaml
@@ -113,6 +113,7 @@ metadata:
   namespace: media
   annotations:
     external-dns.alpha.kubernetes.io/hostname: sabnzbd.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: sabnzbd.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: sabnzbd
     app.kubernetes.io/name: arr

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -383,6 +383,7 @@ metadata:
     app.kubernetes.io/component: searxng
   annotations:
     external-dns.alpha.kubernetes.io/hostname: searxng.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: searxng.k8s.somemissing.info
 spec:
   type: ClusterIP
   ports:

--- a/sonarr.yaml
+++ b/sonarr.yaml
@@ -113,6 +113,7 @@ metadata:
   namespace: media
   annotations:
     external-dns.alpha.kubernetes.io/hostname: sonarr.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: sonarr.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: sonarr
     app.kubernetes.io/name: arr

--- a/thanos/thanos-receive-router-service.yaml
+++ b/thanos/thanos-receive-router-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     external-dns.alpha.kubernetes.io/hostname: prom-remote-write.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: prom-remote-write.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: thanos-receive-router
     app.kubernetes.io/instance: thanos-receive

--- a/vendored/contour/envoy-lb-service.yaml
+++ b/vendored/contour/envoy-lb-service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: projectcontour
   annotations:
     external-dns.alpha.kubernetes.io/hostname: contour.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: contour.k8s.somemissing.info
 spec:
   ports:
   - port: 80

--- a/woodpecker/woodpecker_gui.yaml
+++ b/woodpecker/woodpecker_gui.yaml
@@ -26,6 +26,7 @@ metadata:
   namespace: woodpecker
   annotations:
     external-dns.alpha.kubernetes.io/hostname: woodpecker.k8s.somemissing.info
+    external-dns.kubernetes.io/hostname: woodpecker.k8s.somemissing.info
   labels:
     app.kubernetes.io/name: server
     app.kubernetes.io/instance: woodpecker


### PR DESCRIPTION
Step 1 of the annotation-prefix migration discussed in #460: adds
`external-dns.kubernetes.io/hostname` beside every legacy
`external-dns.alpha.kubernetes.io/hostname` annotation — 18 services
across 16 files (plain manifests, Helm `valuesObject` blocks, and the
contour `envoy-lb` kustomize patch, which lives outside the
vendir-synced `base/`).

**No-op by design**: the deployment still pins
`--annotation-prefix=external-dns.alpha.kubernetes.io/`, and v0.22
reads only the pinned prefix, so the desired set is unchanged. Safe
regardless of apply order.

Migration sequence (each step must merge and sync before the next):

1. **this PR** — stage GA keys alongside alpha (inert).
2. flip the flag to the GA prefix (or drop it; GA is the default) —
   reads the keys added here, identical desired set.
3. remove the alpha keys — nothing reads them anymore.

Do not combine steps: Argo doesn't order resource applies within a
sync, so a services-before-deployment ordering would recreate the
empty-desired-set window that purged ~35 records on the v0.22 upgrade.