### PR TITLE
chore: flip external-dns annotation prefix to GA

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -96,7 +96,7 @@ spec:
                 key: tsig-secret
         args:
         - --policy=sync
-        - --annotation-prefix=external-dns.alpha.kubernetes.io/
+        - --annotation-prefix=external-dns.kubernetes.io/
         - --registry=txt
         - --txt-prefix=external-dns-
         - --txt-owner-id=k8s


### PR DESCRIPTION
Step 2 of the annotation-prefix migration (#460 → #461 → this):
switch the pinned prefix from `external-dns.alpha.kubernetes.io/` to
`external-dns.kubernetes.io/`.

Safe to merge now: #461 synced, and all 18 services verified live
with both keys (`alpha=18 ga=18`), values identical — so the desired
set is unchanged before and after the flip.

The flag stays explicit rather than dropped to rely on the default:
implicit defaults are what armed the v0.22 incident, and upstream
[adeae1d](https://github.com/kubernetes-sigs/external-dns/commit/adeae1d08b38716122c3ca6f9135abf27fd4c3cd)
will require `--annotation-prefix` to be set explicitly in a future
release anyway.

Step 3 (follow-up): remove the alpha keys — nothing will read them
once this syncs.