### PR TITLE
chore: drop legacy external-dns alpha annotations

### DIFF
--- a/application.argocd.yaml
+++ b/application.argocd.yaml
@@ -216,5 +216,4 @@ spec:
               enabled: true
           service:
             annotations:
-              external-dns.alpha.kubernetes.io/hostname: argocd.k8s.somemissing.info
               external-dns.kubernetes.io/hostname: argocd.k8s.somemissing.info

--- a/application.hyperdx.yaml
+++ b/application.hyperdx.yaml
@@ -79,7 +79,6 @@ metadata:
   name: hyperdx-app
   namespace: hyperdx
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: hyperdx.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: hyperdx.k8s.somemissing.info
 spec:
   type: ClusterIP

--- a/application.kube-prometheus.yaml
+++ b/application.kube-prometheus.yaml
@@ -51,7 +51,6 @@ spec:
             portName: https-web
             appProtocol: https
             annotations:
-              external-dns.alpha.kubernetes.io/hostname: grafana.k8s.somemissing.info
               external-dns.kubernetes.io/hostname: grafana.k8s.somemissing.info
           serviceMonitor:
             interval: 30s
@@ -244,7 +243,6 @@ spec:
         prometheus:
           service:
             annotations:
-              external-dns.alpha.kubernetes.io/hostname: prometheus.k8s.somemissing.info
               external-dns.kubernetes.io/hostname: prometheus.k8s.somemissing.info
           prometheusSpec:
             replicas: 2

--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -267,7 +267,6 @@ spec:
 
         service:
           annotations:
-            external-dns.alpha.kubernetes.io/hostname: otel-collector.k8s.somemissing.info
             external-dns.kubernetes.io/hostname: otel-collector.k8s.somemissing.info
 
         serviceMonitor:
@@ -306,7 +305,6 @@ metadata:
   name: otel-collector-syslog
   namespace: monitoring
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: syslog.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: syslog.k8s.somemissing.info
 spec:
   type: LoadBalancer

--- a/application.vikunja.yaml
+++ b/application.vikunja.yaml
@@ -63,7 +63,6 @@ spec:
               # for the ClusterIP. Front the container's 3456 with port 80 so the
               # public URL needs no port suffix.
               annotations:
-                external-dns.alpha.kubernetes.io/hostname: vikunja.k8s.somemissing.info
                 external-dns.kubernetes.io/hostname: vikunja.k8s.somemissing.info
               ports:
                 http:

--- a/docs/agent-memory/project_serviceip_routable.md
+++ b/docs/agent-memory/project_serviceip_routable.md
@@ -8,11 +8,15 @@ In this cluster, the Kubernetes Service network is routable from outside the clu
 
 **Why:** The cluster's Service CIDR is routable on the surrounding network, so LoadBalancer/Ingress isn't needed for L4 exposure. Many existing services (e.g. `sonarr.yaml`, `prowlarr.yaml`, `application.otel-collector.yaml`) already use this pattern.
 
-**How to apply:** When the user asks to "expose" a Service externally, default to ClusterIP + `external-dns.alpha.kubernetes.io/hostname` annotation. Do not propose LoadBalancer, NodePort, or Ingress/HTTPProxy unless the user specifically wants L7 features (TLS termination, host/path routing, auth) — and even then, ask first.
+**How to apply:** When the user asks to "expose" a Service externally, default to ClusterIP + `external-dns.kubernetes.io/hostname` annotation. Do not propose LoadBalancer, NodePort, or Ingress/HTTPProxy unless the user specifically wants L7 features (TLS termination, host/path routing, auth) — and even then, ask first.
 
-**Caveat (2026-08-20):** external-dns v0.22 changed its default annotation
-prefix to the GA `external-dns.kubernetes.io/`, so the deployment must pin
-`--annotation-prefix=external-dns.alpha.kubernetes.io/` so external-dns reads
-these annotations. Without the flag the service source produces an empty desired set
-and `--policy=sync` deletes every service-sourced record it owns (incident:
-~35 records purged on the v0.22 upgrade, PR #460 restored the prefix).
+**Caveat (2026-08-20 incident, resolved 2026-08-21):** external-dns v0.22
+switched its default annotation prefix to the GA `external-dns.kubernetes.io/`;
+these services still used the alpha prefix, so the service source produced an
+empty desired set and sync deleted every service-sourced record it owned
+(~35 records; PRs #459/#460 recovered). All services now carry the GA
+`external-dns.kubernetes.io/hostname` key, and the deployment pins
+`--annotation-prefix=external-dns.kubernetes.io/` explicitly (migration: #461
+staged the GA keys, #464 flipped the flag, this PR removed the alpha keys).
+Annotate new Services with the GA key, and keep the flag explicit so a future
+default change cannot silently empty the desired set again.

--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -119,7 +119,6 @@ metadata:
   name: jellyfin
   namespace: media
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: jellyfin.apps.somemissing.info
     external-dns.kubernetes.io/hostname: jellyfin.apps.somemissing.info
   labels:
     app.kubernetes.io/component: jellyfin-server

--- a/mumble.yaml
+++ b/mumble.yaml
@@ -95,7 +95,6 @@ metadata:
   name: mumble
   namespace: default
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: mumble.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: mumble.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: mumble-server

--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -212,7 +212,6 @@ metadata:
     # ClusterIPs are routable on the LAN (Calico advertises the Service CIDR to
     # the gateway over BGP), so a plain ClusterIP plus this annotation is all an
     # agent outside the cluster needs -- see "DNS zones and TLS" in README.md.
-    external-dns.alpha.kubernetes.io/hostname: agents-otel.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: agents-otel.k8s.somemissing.info
 spec:
   type: ClusterIP

--- a/prowlarr.yaml
+++ b/prowlarr.yaml
@@ -112,7 +112,6 @@ metadata:
   name: prowlarr
   namespace: media
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: prowlarr.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: prowlarr.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: prowlarr

--- a/radarr.yaml
+++ b/radarr.yaml
@@ -112,7 +112,6 @@ metadata:
   name: radarr
   namespace: media
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: radarr.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: radarr.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: radarr

--- a/sabnzbd.yaml
+++ b/sabnzbd.yaml
@@ -112,7 +112,6 @@ metadata:
   name: sabnzbd
   namespace: media
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: sabnzbd.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: sabnzbd.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: sabnzbd

--- a/searxng.yaml
+++ b/searxng.yaml
@@ -382,7 +382,6 @@ metadata:
     app.kubernetes.io/name: searxng
     app.kubernetes.io/component: searxng
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: searxng.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: searxng.k8s.somemissing.info
 spec:
   type: ClusterIP

--- a/sonarr.yaml
+++ b/sonarr.yaml
@@ -112,7 +112,6 @@ metadata:
   name: sonarr
   namespace: media
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: sonarr.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: sonarr.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: sonarr

--- a/thanos/thanos-receive-router-service.yaml
+++ b/thanos/thanos-receive-router-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: prom-remote-write.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: prom-remote-write.k8s.somemissing.info
   labels:
     app.kubernetes.io/component: thanos-receive-router

--- a/vendored/contour/envoy-lb-service.yaml
+++ b/vendored/contour/envoy-lb-service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: envoy-lb
   namespace: projectcontour
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: contour.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: contour.k8s.somemissing.info
 spec:
   ports:

--- a/woodpecker/woodpecker_gui.yaml
+++ b/woodpecker/woodpecker_gui.yaml
@@ -25,7 +25,6 @@ metadata:
   name: woodpecker-server-gui
   namespace: woodpecker
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: woodpecker.k8s.somemissing.info
     external-dns.kubernetes.io/hostname: woodpecker.k8s.somemissing.info
   labels:
     app.kubernetes.io/name: server


### PR DESCRIPTION
Final step of the annotation-prefix migration (#460 → #461 → #464 →
this): removes the 18 `external-dns.alpha.kubernetes.io/hostname`
keys. Nothing reads them since #464 flipped the pinned prefix to GA
and synced, so the desired set is unchanged — no apply-order hazard.

Also updates `docs/agent-memory/project_serviceip_routable.md` to the
end state: annotate with the GA key, keep `--annotation-prefix`
explicit so a future default change cannot silently empty the desired
set (the v0.22 incident mode).

After merge, external-dns should log "All records are already up to
date" straight through the sync.