### PR TITLE
chore(deps): replace bitnami memcached chart with cloudpirates

### DIFF
--- a/application.thanos-caching-bucket.yaml
+++ b/application.thanos-caching-bucket.yaml
@@ -26,35 +26,16 @@ spec:
       limit: 2
   source:
     chart: memcached
-    # repoURL: https://charts.bitnami.com/bitnami
-    repoURL: registry-1.docker.io/bitnamicharts
-    targetRevision: 8.7.8
+    repoURL: registry-1.docker.io/cloudpirates
+    targetRevision: 0.14.7
     helm:
       releaseName: caching-bucket
       valuesObject:
-        global:
-          security:
-            allowInsecureImages: true
-        image:
-          registry: docker.io
-          repository: memcached
-          tag: "1.6-alpine"
-        architecture: standalone
-        # architecture: high-availability
-        # autoscaling:
-        #   enabled: true
-        #   minReplicas: 1
-        #   maxReplicas: 3
-        #   targetCPU: 400
-        #   targetMemory: 200
         service:
           type: ClusterIP
           clusterIP: None
-        command:
-        - memcached
-        args:
-        - -m
-        - "256"
+        config:
+          memoryLimit: 256
         resources:
           requests:
             cpu: 50m
@@ -64,7 +45,7 @@ spec:
             memory: 600Mi
         pdb:
           create: true
-          minAvailable: 0 # not HA
+          minAvailable: "0" # not HA
         metrics:
           enabled: true
           image:

--- a/application.thanos-index-cache.yaml
+++ b/application.thanos-index-cache.yaml
@@ -26,35 +26,16 @@ spec:
       limit: 2
   source:
     chart: memcached
-    # repoURL: https://charts.bitnami.com/bitnami
-    repoURL: registry-1.docker.io/bitnamicharts
-    targetRevision: 8.7.8
+    repoURL: registry-1.docker.io/cloudpirates
+    targetRevision: 0.14.7
     helm:
       releaseName: index-cache
       valuesObject:
-        global:
-          security:
-            allowInsecureImages: true
-        image:
-          registry: docker.io
-          repository: memcached
-          tag: "1.6-alpine"
-        architecture: standalone
-        # architecture: high-availability
-        # autoscaling:
-        #   enabled: true
-        #   minReplicas: 1
-        #   maxReplicas: 3
-        #   targetCPU: 400
-        #   targetMemory: 200
         service:
           type: ClusterIP
           clusterIP: None
-        command:
-        - memcached
-        args:
-        - -m
-        - "256"
+        config:
+          memoryLimit: 256
         resources:
           requests:
             cpu: 50m
@@ -64,7 +45,7 @@ spec:
             memory: 600Mi
         pdb:
           create: true
-          minAvailable: 0 # not HA
+          minAvailable: "0" # not HA
         metrics:
           enabled: true
           image:


### PR DESCRIPTION
Migrates both Thanos memcached Applications (`thanos-bucket-memcached`, `thanos-index-memcached`) off `bitnamicharts/memcached` 8.7.7 to the actively maintained CloudPirates chart (`oci://registry-1.docker.io/cloudpirates/memcached` 0.14.7), per the avoid-Bitnami policy in `docs/agent-memory/feedback_avoid_bitnami.md`.

- Release names unchanged, so rendered fullnames still match the DNS entries in `thanos/thanos-store-*-secret.yaml`
- Values remapped to the new schema; memcached image now comes from the chart default (digest-pinned upstream `docker.io/memcached:1.6.45`) instead of the `1.6-alpine` override
- Exporter override kept explicit so Renovate's `helm-values` manager continues tracking `docker.io/prom/memcached-exporter`; no `renovate.json` changes needed — the `argocd` manager picks up the new OCI path automatically
- Verified locally with `helm template` (name/kind parity vs old chart), kubeconform, and yamllint-vs-baseline

Rollout note: on first sync, if ArgoCD reports an immutable-field conflict on the Deployment/Service, delete the old workload before retrying — caches are ephemeral. The old PDB is pruned (replacement is named `<fullname>-pdb`).