### PR TITLE
fix(renovate): substitute new value in autoreplace template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
         "# renovate: datasource=(?<datasource>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\s+depName=(?<depName>\\S+)\\s*\\n\\s*version:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?"
       ],
       "datasourceTemplate": "{{#if datasource}}{{datasource}}{{else}}docker{{/if}}",
-      "autoReplaceStringTemplate": "{{#if newDigest}}{{#if currentDigest}}{{{replace currentDigest newDigest replaceString}}}{{else}}{{{replaceString}}}@{{{newDigest}}}{{/if}}{{else}}{{{replaceString}}}{{/if}}"
+      "autoReplaceStringTemplate": "{{#if newDigest}}{{#if currentDigest}}{{{replace currentDigest newDigest replaceString}}}{{else}}{{{replaceString}}}@{{{newDigest}}}{{/if}}{{else}}{{{replace currentValue newValue replaceString}}}{{/if}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
The custom regex manager's `autoReplaceStringTemplate` no-digest branch rendered the matched text verbatim, so version-only bumps produced an unchanged file and failed Renovate's post-update check ("Value is not updated" → `update failure`). First observed on the otel-agent-trace-connector v0.1.0 → v0.2.0 bump; ~40 other annotations across the repo would fail the same way on their next version bump. Digest-append and digest-swap branches are unchanged.

After merge, Mend's next run should successfully open the trace-connector v0.2.0 PR.