### PR TITLE
feat: expose prometheus-ext web on a routable ClusterIP

### DIFF
--- a/prometheus-ext.yaml
+++ b/prometheus-ext.yaml
@@ -64,6 +64,28 @@ spec:
     app.kubernetes.io/name: prometheus
     prometheus: ext
 ---
+# The headless service above must stay clusterIP: None (it is the
+# Prometheus StatefulSet's governing service); this regular ClusterIP
+# gives clients a stable virtual IP across both replicas and carries the
+# external-dns GA hostname annotation (cluster Service IPs are routable
+# off-cluster).
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-ext-web
+  namespace: monitoring
+  annotations:
+    external-dns.kubernetes.io/hostname: prometheus-ext.k8s.somemissing.info
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 9090
+    targetPort: web
+  selector:
+    app.kubernetes.io/name: prometheus
+    prometheus: ext
+---
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Adds a second Service (prometheus-ext-web) next to the existing headless one in prometheus-ext.yaml. The headless service stays as the StatefulSet governing service; the new ClusterIP gives a stable VIP across both replicas.

Merging publishes prometheus-ext.k8s.somemissing.info via external-dns (GA annotation key) pointing at the Service IP, which is routable off-cluster.