### PR TITLE
fix: match renovate-release-api alerts to actual metric labels

### DIFF
--- a/renovate-release-api.yaml
+++ b/renovate-release-api.yaml
@@ -231,19 +231,21 @@ spec:
           endpoint externally: GET
           https://renovate-releases.apps.somemissing.info/v1/releases/nijave/cukk
           should answer 200 with a non-empty releases array.
-      # The operator renders ServiceMonitor jobs as
-      # "serviceMonitor/<namespace>/<name>/<endpoint>", so match on a
-      # regex rather than the bare CR name.
-      expr: up{job=~"serviceMonitor/default/renovate-release-api/.*"} != 1 or absent(up{job=~"serviceMonitor/default/renovate-release-api/.*"})
+      # The scrape pool is named
+      # "serviceMonitor/default/renovate-release-api/0", but with no
+      # spec.jobLabel set the operator's default relabeling rewrites the
+      # exported job label to the bare service name — match that.
+      expr: up{job="renovate-release-api",namespace="default"} != 1 or absent(up{job="renovate-release-api",namespace="default"})
       for: 30m
       labels:
         severity: warning
 ---
 # Blackbox probes of the real public endpoint (targets in
-# application.blackbox-exporter.yaml, module renovate_releases_2xx): 200
-# plus a non-empty releases array per tracked image. These catch
-# TLS/routing/edge failures the /healthz ServiceMonitor above cannot see;
-# the module label is unique to these probes, so no job-name guessing.
+# application.blackbox-exporter.yaml): 200 plus a non-empty releases
+# array per tracked image. These catch TLS/routing/edge failures the
+# /healthz ServiceMonitor above cannot see. The chart does not relabel
+# a module label onto probe series, so match on the instance URL prefix
+# (unique to these probes) instead.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -267,7 +269,9 @@ spec:
           self-built images (the "Silent freeze" risk in
           docs/renovate-private-registry-datasource-design.md). Check the
           endpoint by hand, then the deployment and RenovateReleaseApiDown.
-      expr: 'probe_success{module="renovate_releases_2xx"} == 0'
+      # PromQL string escapes: \\ in the single-quoted YAML reaches PromQL
+      # as an escaped backslash, so the regex sees \. as a literal dot.
+      expr: 'probe_success{instance=~"https://renovate-releases\\.apps\\.somemissing\\.info/v1/releases/.*"} == 0'
       for: 2m
       labels:
         severity: warning


### PR DESCRIPTION
## Root cause

`RenovateReleaseApiDown` has been firing continuously since rollout (activeAt 2026-08-16T23:16:30Z) even though the service is fully healthy — pod Ready on the pinned digest, `/healthz` scrape target up (`up == 1`), all six public blackbox probes passing. The rule matched a job label format this cluster's Prometheus operator (v0.93.1) never exports:

- The string `serviceMonitor/default/renovate-release-api/0` exists only as the internal scrape-pool `job_name` in the generated config.
- With no `spec.jobLabel` set on the ServiceMonitor, the operator's default relabeling rewrites the exported `job` label to the bare service name (`renovate-release-api`).
- So the regex matched zero series and the `absent(...)` branch fired permanently.

The companion rule had the inverse bug: `RenovateReleasesEndpointFailing` matched `probe_success{module="renovate_releases_2xx"}`, but probe series carry no `module` label (the blackbox chart doesn't relabel one onto series) — it could never fire at all.

## Changes

- `RenovateReleaseApiDown`: match `up{job="renovate-release-api",namespace="default"}`; comment corrected to describe the real relabeling behavior.
- `RenovateReleasesEndpointFailing`: match `probe_success` by instance URL prefix (unique to these six probes); comment corrected accordingly.

## Validation

- Repo kubeconform/pluto hooks pass.
- Both replacement exprs were round-tripped against live Prometheus exactly as they appear in the YAML: they parse, select the intended series (1 healthz series; 6 probe series), and evaluate empty while healthy — so the firing alert resolves on sync.
- Note on PromQL escaping: `\.` in single-quoted YAML is required; a plain `\.` fails PromQL parsing under this setup (utf8 validation scheme rejects the unknown escape).

## Checked and intentionally unchanged

- `rtorrent-alerts.yaml` uses a `scrapeConfig/<ns>/<name>` job matcher that looked wrong when checked against prom-kp, but its rules are evaluated by the `ext` Prometheus, where the ScrapeConfig series does exist with the prefixed label (`job="scrapeConfig/monitoring/rtorrent-exporter"`). Correct as written.

After merge + Argo sync, expect `RenovateReleaseApiDown` to resolve within one rule evaluation cycle.