### PR TITLE
fix: raise snmp-exporter scrape timeout to 25s

### DIFF
--- a/snmp-exporter.yaml
+++ b/snmp-exporter.yaml
@@ -169,6 +169,7 @@ spec:
   - targetPort: &targetPort 9116
     path: &path /snmp
     interval: &interval 30s
+    scrapeTimeout: &scrapeTimeout 25s
     relabelings: &relabelings
       - action: replace
         sourceLabels: [__param_target]
@@ -182,6 +183,7 @@ spec:
   - targetPort: *targetPort
     path: *path
     interval: *interval
+    scrapeTimeout: *scrapeTimeout
     relabelings: *relabelings
     params:
       auth: [core-switch]
@@ -190,6 +192,7 @@ spec:
   - targetPort: *targetPort
     path: *path
     interval: *interval
+    scrapeTimeout: *scrapeTimeout
     relabelings: *relabelings
     params:
       auth: [tp-link-omada]
@@ -198,6 +201,7 @@ spec:
   - targetPort: *targetPort
     path: *path
     interval: *interval
+    scrapeTimeout: *scrapeTimeout
     relabelings: *relabelings
     params:
       auth: [tp-link-omada]
@@ -206,6 +210,7 @@ spec:
   - targetPort: *targetPort
     path: *path
     interval: *interval
+    scrapeTimeout: *scrapeTimeout
     relabelings: *relabelings
     params:
       auth: [tp-link-omada]
@@ -214,6 +219,7 @@ spec:
   - targetPort: *targetPort
     path: *path
     interval: *interval
+    scrapeTimeout: *scrapeTimeout
     relabelings: *relabelings
     params:
       auth: [office-switch]
@@ -222,6 +228,7 @@ spec:
   - targetPort: *targetPort
     path: *path
     interval: *interval
+    scrapeTimeout: *scrapeTimeout
     relabelings: *relabelings
     params:
       auth: [tp-link-omada]


### PR DESCRIPTION
## Why

The `172.16.1.21` target (TP-Link SG3218XP-M2) currently fails every
scrape: full `if_mib` walks take ~10s from the exporter, which sits
exactly at Prometheus' default 10s scrape timeout. The target flapped
at ~60% success for days and has now degraded to 0% success.

Measurements behind the change:

- walk = 361 varbinds / ~13-15 GETBULK round-trips; the switch serves
  each request in ~0.66s, totaling ~9.9s per successful scrape
- `snmp_scrape_packets_retried` is 0 on successes, so this is agent
  slowness, not UDP loss — retransmit tuning won't help

## What

Per-endpoint `scrapeTimeout: 25s` (new shared anchor, applied to all
7 SNMP endpoints) under the unchanged 30s interval. Follows the
existing in-repo precedent of endpoint-level timeouts
(`application.kube-prometheus.yaml` grafana endpoint). No Prometheus
CR global changes needed since the timeout stays under the interval.

## Validation

- `.ci/validate.sh`: all manifests valid (kubeconform strict)
- pre-commit kubeconform + pluto hooks passed
- YAML anchors verified expanded: all 7 endpoints report 30s/25s