### PR TITLE
fix: cap agent trace export batches under the 4 MiB gRPC limit

### DIFF
--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -79,7 +79,11 @@ data:
             value: coding-agent
             action: upsert
       batch:
-        send_batch_size: 1024
+        # 256 spans keeps an export well under the 4 MiB gRPC message limit on
+        # every hop to otel-collector. At 1024, fat agent batches reach ~5 MB
+        # and ResourceExhausted is permanent -- exporterhelper drops them
+        # outright (~14k spans/hour observed).
+        send_batch_size: 256
         timeout: 5s
 
     exporters:


### PR DESCRIPTION
## Problem

The connector's `otlp_grpc` exporter is permanently dropping trace batches. Pod logs show ~10 drops/hour, **14,368 spans dropped in one hour**:

```
Permanent error: rpc error: code = ResourceExhausted desc = grpc: received message
larger than max (5034593 vs. 4194304)   dropped_items: 971
```

Both pre- and post-decompression size rejections appear, so batches exceed 4 MiB on every hop between this collector and `otel-collector.k8s.somemissing.info:4317`. `ResourceExhausted` is treated as non-retryable by exporterhelper, so each oversized batch is discarded outright rather than queued.

## Fix

Lower `batch.send_batch_size` from 1024 to 256. Observed oversized batches were ~5 MB at 1024 spans (~5 KB/span average for chatty opencode spans), so 256 keeps typical exports around 1.3 MB with headroom even for unusually fat spans.

Chosen over raising message-size limits on both ends or adding compression because it is a single-line change confined to this file and bounds payload size regardless of what the downstream receiver accepts.

## Rollout

Automated ArgoCD sync picks this up; the reloader annotation rolls the pod on ConfigMap change. Single replica with Recreate strategy, so a brief ingest gap during the roll is expected and already an accepted cost per the existing comments.