### PR TITLE
fix: tighten agent trace export batch trigger and cap

### DIFF
--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -79,11 +79,17 @@ data:
             value: coding-agent
             action: upsert
       batch:
-        # 256 spans keeps an export well under the 4 MiB gRPC message limit on
-        # every hop to otel-collector. At 1024, fat agent batches reach ~5 MB
-        # and ResourceExhausted is permanent -- exporterhelper drops them
-        # outright (~14k spans/hour observed).
-        send_batch_size: 256
+        # Both values keep an export well under the 4 MiB gRPC message limit
+        # on every hop to otel-collector. At 1024 spans, fat agent batches
+        # reach ~5 MB and ResourceExhausted is permanent -- exporterhelper
+        # drops them outright (~14k spans/hour observed).
+        # send_batch_size triggers a send; send_batch_max_size additionally
+        # splits a single large delivery into multiple capped exports, so no
+        # outgoing batch exceeds 64 spans even when one OTLP request arrives
+        # far larger. The cap is per-item, not per-byte: ~5 KB/span observed
+        # leaves ample headroom.
+        send_batch_size: 16
+        send_batch_max_size: 64
         timeout: 5s
 
     exporters:


### PR DESCRIPTION
Follow-up to #485. Two changes to the batch processor:

- `send_batch_size: 256` → `16` — sends trigger much earlier, so exports flush almost immediately rather than accumulating.
- Add `send_batch_max_size: 64` — hard-caps every outgoing batch by splitting oversized deliveries (verified against the pinned collector v0.159.0: every export passes through `batch.split(sendBatchMaxSize)`, so even a single large OTLP request cannot produce an oversized message). This setting was part of the original fix but landed after that PR merged.

Worst case is now 64 spans/export (~320 KB at the observed ~5 KB/span average), a >10x margin under the 4 MiB gRPC limit that caused ~14k dropped spans/hour in #485.

Rollout unchanged from #485: automated ArgoCD sync + reloader rolls the single-replica pod.