### PR TITLE
docs: add claude-code model trends HyperDX dashboard export

### DIFF
--- a/docs/dashboards/claude-code-model-trends.json
+++ b/docs/dashboards/claude-code-model-trends.json
@@ -1,0 +1,106 @@
+{
+  "_id": "6a8b5924aeb892a415c3446b",
+  "name": "claude-code model trends",
+  "tiles": [
+    {
+      "id": "ln-err-hour",
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] != 'true') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Error rate % by model (hourly)"
+      }
+    },
+    {
+      "id": "ln-err-5m",
+      "x": 12,
+      "y": 0,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] != 'true') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Error rate % by model (5 min)"
+      }
+    },
+    {
+      "id": "ln-tok-hour",
+      "x": 0,
+      "y": 8,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Generation tok/sec by model (hourly)"
+      }
+    },
+    {
+      "id": "ln-tok-5m",
+      "x": 12,
+      "y": 8,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Generation tok/sec by model (5 min)"
+      }
+    },
+    {
+      "id": "ln-lat-hour",
+      "x": 0,
+      "y": 16,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(toFloat64OrZero(SpanAttributes['duration_ms']))) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Latency p50/p90/p99 by model (hourly)"
+      }
+    },
+    {
+      "id": "ln-lat-5m",
+      "x": 12,
+      "y": 16,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(toFloat64OrZero(SpanAttributes['duration_ms']))) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Latency p50/p90/p99 by model (5 min)"
+      }
+    }
+  ],
+  "team": "69d6f9db842db143c17e053b",
+  "tags": [],
+  "filters": [],
+  "savedFilterValues": [],
+  "containers": [],
+  "createdBy": "69d6f9db842db143c17e0537",
+  "updatedBy": "69d6f9db842db143c17e0537",
+  "provisioned": false,
+  "createdAt": "2026-08-23T20:33:40.628Z",
+  "updatedAt": "2026-08-23T20:33:40.628Z"
+}

--- a/docs/dashboards/claude-code-model-trends.md
+++ b/docs/dashboards/claude-code-model-trends.md
@@ -1,0 +1,87 @@
+# claude-code model trends (HyperDX dashboard)
+
+Export and notes for the **`claude-code model trends`** dashboard that lives in
+the HyperDX/ClickStack instance in the `hyperdx` namespace.
+
+- **Live location:** MongoDB `hyperdx` database, `dashboards` collection.
+- **Dashboard `_id`:** `6a519951318e69d22b7658fd`'s sibling — this document is
+  `6a8b5924aeb892a415c3446b`.
+- **Export snapshot:** [`claude-code-model-trends.json`](./claude-code-model-trends.json)
+  (full dashboard document as stored in Mongo).
+- **Data source:** ClickHouse `otel.otel_traces`, filtered to
+  `SpanName = 'claude_code.llm_request'` and `ServiceName = 'claude-code'`,
+  same as [`claude-code-model-metrics.md`](./claude-code-model-metrics.md).
+  Where that dashboard is table/KPI-oriented, this one is time-series only.
+
+## Tiles
+
+All six tiles are raw-SQL line charts (`displayType: "line"`,
+`configType: "sql"`), paired hourly / 5-minute so the right granularity is
+available at both day-scale and hour-scale zoom:
+
+| id | granularity | what it shows |
+| --- | --- | --- |
+| `ln-err-hour` | hourly | error rate % by model (`success != 'true'`) |
+| `ln-err-5m` | 5-minute | error rate % by model |
+| `ln-tok-hour` | hourly | generation tok/sec by model |
+| `ln-tok-5m` | 5-minute | generation tok/sec by model |
+| `ln-lat-hour` | hourly | p50/p90/p99 latency (ms) per model × percentile |
+| `ln-lat-5m` | 5-minute | p50/p90/p99 latency (ms) per model × percentile |
+
+Line-chart SQL shape: each query returns a timestamp column (`ts`), a series
+name column, and a value column, then `GROUP BY <series>, ts`. This matches the
+contract ClickStack documents for raw-SQL line charts. The latency tile folds
+model and percentile into one series name (`<model> · p90`) because the chart
+renders a single group column; it uses
+`arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(...))` expanded with
+`ARRAY JOIN`. Generation tok/sec reuses the `gen_toks` formula from the model
+metrics dashboard:
+`sum(output_tokens) / greatest(sum(duration_ms - ttft_ms), 1) * 1000`.
+
+## Known limitations
+
+- **No interactive filters.** Dashboard-level filters do not inject into
+  raw-SQL tiles, so there is no percentile/model picker; every series renders.
+  To isolate a percentile visually, read the `<model> · pNN` legend entries.
+- **Series count grows with models used.** Each new `gen_ai.request.model`
+  value adds lines to all six tiles (×3 on the latency tiles).
+- **Sparse buckets render as gaps.** Models used intermittently show broken
+  lines rather than zero-filled ones.
+
+## Applying / re-exporting
+
+Same procedure as the model metrics dashboard: dashboards live in the Mongo
+replica set backing HyperDX; the connection string is in the
+`hyperdx-mongo-app-connection` secret (namespace `hyperdx`); do not print it —
+feed it straight into `mongosh` from inside a mongod pod.
+
+```sh
+CONN=$(kubectl get secret -n hyperdx hyperdx-mongo-app-connection \
+  -o jsonpath='{.data.connectionString\.standard}' | base64 -d)
+
+# Export the live dashboard
+kubectl exec -n hyperdx hyperdx-0 -c mongod -i -- \
+  mongosh "$CONN" --quiet --eval \
+  'JSON.stringify(db.getSiblingDB("hyperdx").dashboards.findOne({name:"claude-code model trends"}), null, 2)'
+```
+
+Edits are made directly against the `dashboards` collection (e.g.
+`replaceOne({name: ...}, doc, {upsert: true})` to recreate or update the whole
+document). Changes are picked up by the HyperDX app without a restart. The
+`_id` in the JSON export is informational — the live document is matched by
+`name`.
+
+Before applying tile SQL changes, validate them against ClickHouse directly by
+substituting real epoch-milli values for the `{startDateMilliseconds:Int64}` /
+`{endDateMilliseconds:Int64}` placeholders (see
+[`../hyperdx-dashboards.md`](../hyperdx-dashboards.md) for why there is no
+`{timeFilter}` macro in raw-SQL tiles).
+
+## Project attribution
+
+These spans carry no project/repo dimension by default. See
+[`../claude-code-otel-project-attribution.md`](../claude-code-otel-project-attribution.md)
+for the shell wrapper that adds `vcs.*` / `process.working_directory` resource
+attributes. Once sessions emit `vcs.repository.name`, a repo dimension can be
+added to these tiles the same way as described for the model metrics dashboard
+— but note it multiplies the series count further (repo × model × percentile).

--- a/docs/dashboards/claude-code-model-trends.md
+++ b/docs/dashboards/claude-code-model-trends.md
@@ -71,6 +71,21 @@ document). Changes are picked up by the HyperDX app without a restart. The
 `_id` in the JSON export is informational — the live document is matched by
 `name`.
 
+### Gotcha: BSON types on insert
+
+The JSON export is not insertable as-is via `mongosh`. The app stores and
+queries several fields with specific BSON types; if they are inserted as plain
+strings/ISO strings, **the dashboard silently disappears from the UI list**
+(the list query filters `team` by ObjectId, so a string-typed `team` never
+matches). When inserting/updating from a script, cast:
+
+- `team`, `createdBy`, `updatedBy` → `ObjectId(...)`
+- `createdAt`, `updatedAt` → `new Date("...")`
+- include `__v: 0`
+
+Symptom of getting this wrong: `findOne({name: ...})` still returns the doc,
+but it never appears in the dashboards list.
+
 Before applying tile SQL changes, validate them against ClickHouse directly by
 substituting real epoch-milli values for the `{startDateMilliseconds:Int64}` /
 `{endDateMilliseconds:Int64}` placeholders (see


### PR DESCRIPTION
## Summary
- Export snapshot + notes for the new `claude-code model trends` HyperDX dashboard (`6a8b5924aeb892a415c3446b` in the Mongo `dashboards` collection), following the existing `claude-code-model-metrics` doc pattern
- Six raw-SQL line-chart tiles: error rate % by model, generation tok/sec by model, and p50/p90/p99 latency per model×percentile — each at hourly and 5-minute granularity
- Documents the line-tile SQL shape (timestamp / series-name / value columns, `ARRAY JOIN` over `quantiles` for percentiles), known limitations (no interactive filters on raw-SQL tiles), and apply/re-export procedure

## Live change already applied
The dashboard document was inserted directly into Mongo (upsert matched on name) and all six stored `sqlTemplate`s were verified against ClickHouse with real time params before this PR. This PR only adds the repo documentation/snapshot.

## Validation
- [x] Each tile SQL executed against ClickHouse via kubectl with substituted `{startDateMilliseconds}`/`{endDateMilliseconds}` params (964/225/2892/675 rows returned across tiles)
- [x] Dashboard doc re-exported from Mongo and matches the committed JSON snapshot
- [ ] Visual check of rendered charts at hyperdx.k8s.somemissing.info (requires UI login)