### PR TITLE
feat: raise OTLP receive ceilings and cap export batches across the ingest chain

### DIFF
--- a/application.hyperdx.yaml
+++ b/application.hyperdx.yaml
@@ -31,6 +31,20 @@ spec:
     helm:
       releaseName: hyperdx
       valuesObject:
+        global:
+          otelCollector:
+            # Merged into the OpAMP-managed collector config at startup (the
+            # chart wires CUSTOM_OTELCOL_CONFIG_FILE to the mounted file). The
+            # hub's remote config defines otlp/hyperdx but does not set a
+            # receive ceiling, so this leaf survives the merge; validated
+            # against the deployed collector binary (otelcol-hyperdx v0.155.0)
+            # with `otelcol validate` on the full effective config.
+            customConfig: |
+              receivers:
+                otlp/hyperdx:
+                  protocols:
+                    grpc:
+                      max_recv_msg_size_mib: 32
         clickhouse:
           enabled: false
         mongodb:
@@ -72,6 +86,17 @@ spec:
                 secretKeyRef:
                   name: clickhouse-otelcollector-credentials
                   key: password
+          # The collector's memory_limiter is fixed at limit_mib 1500 by the
+          # ClickStack base config; pod limits must stay comfortably above it,
+          # and above the 32 MiB receive ceiling, since inbound gRPC messages
+          # are decompressed before the limiter can gate them.
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
 ---
 apiVersion: v1
 kind: Service

--- a/application.otel-collector.yaml
+++ b/application.otel-collector.yaml
@@ -43,7 +43,13 @@ spec:
         config:
           processors:
             batch:
-              send_batch_size: 1024
+              # 32 spans triggers a send almost immediately; send_batch_max_size
+              # splits any larger delivery so a single export never carries more
+              # than 256 spans. At 1024 with no cap, fat batches reached ~7 MB
+              # and were permanently dropped by the HyperDX collector's 4 MiB
+              # gRPC limit (464k spans lost in 24h on 2026-08-23).
+              send_batch_size: 32
+              send_batch_max_size: 256
               timeout: 5s
             memory_limiter:
               check_interval: 5s
@@ -102,6 +108,12 @@ spec:
               protocols:
                 grpc:
                   endpoint: ${env:MY_POD_IP}:4317
+                  # 32 MiB (collector v0.158 renamed the byte-based
+                  # max_recv_msg_size). Generous ceiling for bursty agent
+                  # deliveries; per-RPC decompression happens before the
+                  # memory_limiter can gate it, so pod memory limits are sized
+                  # to match.
+                  max_recv_msg_size_mib: 32
                   tls:
                     cert_file: /tls/tls.crt
                     key_file:  /tls/tls.key
@@ -241,11 +253,11 @@ spec:
 
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: "1"
+            memory: 2Gi
           requests:
-            cpu: 10m
-            memory: 128Mi
+            cpu: 100m
+            memory: 256Mi
 
         podAnnotations:
           # Restart when the TLS secret rotates (cert-manager renews ~every 60d).

--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -43,6 +43,11 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            # 32 MiB (collector v0.159 renamed the byte-based
+            # max_recv_msg_size). Ceiling for bursty agent deliveries; sized
+            # together with the pod memory limit below, since an inbound
+            # message is decompressed in full before the pipeline can gate it.
+            max_recv_msg_size_mib: 32
             tls:
               cert_file: /tls/tls.crt
               key_file: /tls/tls.key
@@ -191,11 +196,11 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: 10m
-              memory: 128Mi
+              cpu: 50m
+              memory: 256Mi
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: "1"
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /conf


### PR DESCRIPTION
Follow-up to #485/#486/#487. Today's incident showed oversized-batch drops at *every* hop of the coding-agent telemetry chain, not just the connector: the middle `otel-collector` alone permanently discarded **464k spans in 24h** (7.4 MB / 6.3 MB messages rejected by the next hop's 4 MiB gRPC limit). This PR hardens the whole chain, biasing toward generous resources over failure risk per review direction.

## Changes (one commit per component, independently revertible)

**otel-collector** (collector contrib v0.158.0)
- `batch.send_batch_size: 1024 → 32`, add `send_batch_max_size: 256` — same fix class as #486; kills the 464k/day loss at its source.
- `max_recv_msg_size_mib: 32` on the OTLP gRPC receiver for bursty direct-agent traffic.
- Resources 512Mi/500m → **2Gi/1 cpu**, requests raised to 256Mi/100m. The percentage-based memory_limiter scales with the limit; tail_sampling's 300s buffer gets real headroom.

**otel-agent-trace-connector** (collector v0.159.0)
- `max_recv_msg_size_mib: 32` + memory 512Mi→1Gi, cpu 500m→1, requests up accordingly.

**hyperdx / ClickStack** (clickstack-otel-collector v0.155.0)
- `global.otelCollector.customConfig` sets `receivers.otlp/hyperdx.protocols.grpc.max_recv_msg_size_mib: 32`; chart auto-wires `CUSTOM_OTELCOL_CONFIG_FILE` to it.
- Collector pod had **no resource limits at all** while its base config pins `memory_limiter limit_mib: 1500`. Set requests 500m/1Gi, limits 2 cpu/4Gi so the limiter's budget is actually backed.

## Field-name verification

All three collectors have moved off the byte-based `max_recv_msg_size`: source-verified `max_recv_msg_size_mib` (int MiB) in configgrpc at v0.155.0, v0.158.0, and v0.159.0. Using the old name would fail strict config validation.

## Validation performed

- Both Helm charts rendered locally with the exact pinned versions (`opentelemetry-collector-0.170.0`, `clickstack-3.2.0`) and these valuesObject files; rendered ConfigMaps contain the intended batch/receiver settings, resources land on the right deployments, collector image stays 2.35.0 (no unintended bump).
- For HyperDX specifically: pulled the live OpAMP effective config from the running pod, added the receiver leaf, and ran `otelcol validate --config` against the deployed binary inside the container — **VALIDATE_OK**. Merge semantics: the supervisor merges local config_files under the hub's remote config; the remote config defines `otlp/hyperdx` but never sets a receive ceiling, so the new leaf survives. Worst case if that ever changes is a silent revert to 4 MiB (drops resume, #487 alerts fire) — not a crash loop.

## Rollout

ArgoCD auto-syncs all three apps; TLS reloader rolls both single-purpose collectors, the HyperDX subchart rolls its Deployment with maxUnavailable 0. Order-independent: each commit helps alone (#486 caps what enters hop 1; the otel-collector batch cap fixes the biggest leak regardless). After rollout, watch `AgentTraceConnectorExportDrops` go quiet and confirm via `sum(rate(otelcol_exporter_send_failed_spans[6h]))` across all three jobs.