### PR TITLE
feat: add coding-agent model metrics HyperDX dashboard export and notes

### DIFF
--- a/docs/dashboards/coding-agent-model-metrics.json
+++ b/docs/dashboards/coding-agent-model-metrics.json
@@ -1,0 +1,138 @@
+{
+  "_id": "6a8b5d7bc0092c5adc32a03c",
+  "name": "coding-agent model metrics",
+  "tiles": [
+    {
+      "id": "kpi-reqs",
+      "x": 0,
+      "y": 0,
+      "w": 3,
+      "h": 3,
+      "config": {
+        "displayType": "number",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0
+        },
+        "configType": "sql",
+        "sqlTemplate": "SELECT count() AS value FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64})",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Total LLM requests"
+      }
+    },
+    {
+      "id": "kpi-retry",
+      "x": 3,
+      "y": 0,
+      "w": 3,
+      "h": 3,
+      "config": {
+        "displayType": "number",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 1
+        },
+        "configType": "sql",
+        "sqlTemplate": "SELECT round(countIf(toUInt8OrZero(SpanAttributes['attempt']) > 1) * 100.0 / count(), 1) AS value FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64})",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Retry rate %"
+      }
+    },
+    {
+      "id": "kpi-ttft",
+      "x": 6,
+      "y": 0,
+      "w": 3,
+      "h": 3,
+      "config": {
+        "displayType": "number",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0
+        },
+        "configType": "sql",
+        "sqlTemplate": "SELECT round(quantile(0.95)(toFloat64OrZero(SpanAttributes['ttft_ms'])), 0) AS value FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64})",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "TTFT p95 (ms)"
+      }
+    },
+    {
+      "id": "kpi-lat",
+      "x": 9,
+      "y": 0,
+      "w": 3,
+      "h": 3,
+      "config": {
+        "displayType": "number",
+        "numberFormat": {
+          "output": "number",
+          "mantissa": 0
+        },
+        "configType": "sql",
+        "sqlTemplate": "SELECT round(quantile(0.95)(Duration) / 1e6, 0) AS value FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64})",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Latency p95 (ms)"
+      }
+    },
+    {
+      "id": "tbl-models",
+      "x": 0,
+      "y": 3,
+      "w": 24,
+      "h": 10,
+      "config": {
+        "displayType": "table",
+        "configType": "sql",
+        "sqlTemplate": "SELECT SpanAttributes['gen_ai.request.model'] AS model, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, count() AS requests, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct, round(countIf(toUInt8OrZero(SpanAttributes['attempt']) > 1) * 100.0 / count(), 1) AS retry_pct, round(quantile(0.5)(toFloat64OrZero(SpanAttributes['ttft_ms'])), 0) AS ttft_p50_ms, round(quantile(0.95)(toFloat64OrZero(SpanAttributes['ttft_ms'])), 0) AS ttft_p95_ms, round(quantile(0.5)(Duration) / 1e6, 0) AS lat_p50_ms, round(quantile(0.95)(Duration) / 1e6, 0) AS lat_p95_ms, round(quantile(0.99)(Duration) / 1e6, 0) AS lat_p99_ms, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks, round(sum(toFloat64OrZero(SpanAttributes['input_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.input_tokens'])), 0) AS tok_in, round(sum(toFloat64OrZero(SpanAttributes['cache_read_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.cache_read.input_tokens'])), 0) AS tok_cache, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens'])), 0) AS tok_out FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, agent ORDER BY requests DESC",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Per-model metrics"
+      }
+    },
+    {
+      "id": "tbl-agents",
+      "x": 0,
+      "y": 13,
+      "w": 24,
+      "h": 8,
+      "config": {
+        "displayType": "table",
+        "configType": "sql",
+        "sqlTemplate": "SELECT if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, count() AS requests, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct, round(countIf(toUInt8OrZero(SpanAttributes['attempt']) > 1) * 100.0 / count(), 1) AS retry_pct, round(quantile(0.95)(toFloat64OrZero(SpanAttributes['ttft_ms'])), 0) AS ttft_p95_ms, round(quantile(0.95)(Duration) / 1e6, 0) AS lat_p95_ms, round(sum(toFloat64OrZero(SpanAttributes['input_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.input_tokens'])), 0) AS tok_in, round(sum(toFloat64OrZero(SpanAttributes['cache_read_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.cache_read.input_tokens'])), 0) AS tok_cache, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens'])), 0) AS tok_out FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY agent ORDER BY requests DESC",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Per-agent metrics"
+      }
+    },
+    {
+      "id": "tbl-daily",
+      "x": 0,
+      "y": 21,
+      "w": 24,
+      "h": 9,
+      "config": {
+        "displayType": "table",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toDate(Timestamp) AS day, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, count() AS requests, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct, round(countIf(toUInt8OrZero(SpanAttributes['attempt']) > 1) * 100.0 / count(), 1) AS retry_pct, round(quantile(0.95)(toFloat64OrZero(SpanAttributes['ttft_ms'])), 0) AS ttft_p95_ms, round(quantile(0.95)(Duration) / 1e6, 0) AS lat_p95_ms FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY day, agent ORDER BY day, requests DESC",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Daily trend"
+      }
+    }
+  ],
+  "team": "69d6f9db842db143c17e053b",
+  "tags": [],
+  "filters": [],
+  "savedFilterValues": [],
+  "containers": [],
+  "createdBy": "69d6f9db842db143c17e0537",
+  "updatedBy": "69d6f9db842db143c17e0537",
+  "provisioned": false,
+  "createdAt": "2026-08-23T20:52:11.679Z",
+  "updatedAt": "2026-08-23T20:52:11.690Z",
+  "__v": 0
+}

--- a/docs/dashboards/coding-agent-model-metrics.md
+++ b/docs/dashboards/coding-agent-model-metrics.md
@@ -1,0 +1,87 @@
+# coding-agent model metrics (HyperDX dashboard)
+
+Export and notes for the **`coding-agent model metrics`** dashboard that lives
+in the HyperDX/ClickStack instance in the `hyperdx` namespace.
+
+- **Live location:** MongoDB `hyperdx` database, `dashboards` collection.
+- **Dashboard `_id`:** `6a8b5d7bc0092c5adc32a03c`
+- **Export snapshot:** [`coding-agent-model-metrics.json`](./coding-agent-model-metrics.json)
+  (full dashboard document as stored in Mongo).
+- **Data source:** ClickHouse `otel.otel_traces`, filtered to canonical spans
+  from the [otel-agent-trace-connector](../../../otel-agent-trace-connector.yaml):
+  `SpanName LIKE 'chat %'` and
+  `ResourceAttributes['telemetry.source'] = 'coding-agent'`. The connector's
+  `resource/coding_agent` processor tags everything it exports, so this filter
+  selects its output; raw vendor traces forwarded alongside it keep their
+  native span names (`claude_code.*`, `ai.*`, …) and never match.
+- **Sibling of** [`claude-code model metrics`](./claude-code-model-metrics.md) —
+  same tile layout, but scoped to all harnesses the connector normalizes
+  (claude_code, codex, opencode, pi, …) instead of native Claude Code spans.
+
+## Tiles
+
+| id | type | what it shows |
+| --- | --- | --- |
+| `kpi-reqs` | number | total LLM requests |
+| `kpi-retry` | number | retry rate % (`attempt` > 1; only claude_code sets `attempt`) |
+| `kpi-ttft` | number | TTFT p95 (ms; only claude_code sets `ttft_ms`) |
+| `kpi-lat` | number | latency p95 (ms, from span `Duration`) |
+| `tbl-models` | table | per-model × per-agent metrics |
+| `tbl-agents` | table | per-agent totals |
+| `tbl-daily` | table | daily trend per agent |
+
+## Dimension and attribute notes
+
+- **Agent column:** `if(SpanAttributes['coding_agent.client.name'] != '',
+  SpanAttributes['coding_agent.client.name'],
+  if(ServiceName LIKE 'codex%', 'codex', ServiceName))`. Codex canonical spans
+  carry no `coding_agent.client.name`, so they fall back to a normalized
+  ServiceName (`codex_cli_rs`/`codex_exec` → `codex`); every other harness
+  sets it.
+- **Model column:** `gen_ai.request.model` (present on every canonical chat
+  span, unlike the harness-specific `model` attribute).
+- **Latency columns use `Duration`** (nanoseconds, present on every span)
+  rather than the `duration_ms` attribute — opencode/codex chat spans don't
+  set `duration_ms`, so attribute-based latency would silently cover only
+  claude_code.
+- **Token sums combine two attribute families:** claude_code-style
+  (`input_tokens`, `cache_read_tokens`, `output_tokens`) plus GenAI-semconv
+  (`gen_ai.usage.input_tokens`, `gen_ai.usage.cache_read.input_tokens`,
+  `gen_ai.usage.output_tokens`). claude_code uses the first family; codex
+  emits only the second; opencode emits neither (its rows show 0 tokens).
+- **Error rate counts explicit failures only:** `success = 'false'`
+  (not `!= 'true'` as the claude-code dashboard does), because sources that
+  don't emit `success` would otherwise read as 100% errors.
+- **`gen_toks` is guarded:** it is 0 unless `duration_ms - ttft_ms > 0`, so
+  sources without TTFT attributes don't produce an inflated tokens/sec value.
+- **TTFT / retry metrics are claude_code-only today** — those attributes come
+  from Claude Code's native telemetry; other harnesses contribute requests,
+  latency, and (for codex) token totals only.
+
+## Applying / re-exporting
+
+Same procedure as the claude-code dashboard: dashboards live in the Mongo
+replica set backing HyperDX; connection string is in secret
+`hyperdx-mongo-app-connection` (namespace `hyperdx`) — do not print it.
+
+```sh
+CONN=$(kubectl get secret -n hyperdx hyperdx-mongo-app-connection \
+  -o jsonpath='{.data.connectionString\.standard}' | base64 -d)
+
+# Export the live dashboard
+kubectl exec -n hyperdx hyperdx-0 -c mongod -i -- \
+  mongosh "$CONN" --quiet --eval \
+  'JSON.stringify(db.getSiblingDB("hyperdx").dashboards.findOne({name:"coding-agent model metrics"}), null, 2)'
+```
+
+Edits go against the live document matched by `name`; the `_id` in the export
+is informational. Changes are picked up by the HyperDX app without a restart.
+
+## Possible follow-ups
+
+- A `vcs.repository.name` repo dimension — canonical claude_code spans carry
+  it (~40% of spans at creation time). Not added yet to avoid blank-heavy
+  rows; gate on `ResourceAttributes['vcs.repository.name'] != ''` or wait for
+  fuller rollout.
+- If opencode starts emitting usage/latency attributes upstream, revisit the
+  zero-token rows in `tbl-models`.


### PR DESCRIPTION
Adds the repo-side record for a new HyperDX dashboard, `coding-agent model metrics`, created in Mongo (`_id 6a8b5d7bc0092c5adc32a03c`) alongside the existing `claude-code model metrics` dashboard.

- `docs/dashboards/coding-agent-model-metrics.json` — full dashboard export
- `docs/dashboards/coding-agent-model-metrics.md` — tile inventory and attribute/dimension notes

The dashboard mirrors the claude-code one but reads canonical spans from otel-agent-trace-connector (`SpanName LIKE 'chat %'` + `ResourceAttributes['telemetry.source'] = 'coding-agent'`), so it covers claude_code, codex, opencode, and future harnesses. Differences from the source dashboard are documented in the md: agent dimension (with codex ServiceName fallback), latency from span `Duration`, token sums combining claude_code-style and `gen_ai.usage.*` attributes, explicit-failure-only error rate, and a guarded `gen_toks`. All tile SQL was validated against ClickHouse before creation.