### PR TITLE
docs: add coding-agent model trends HyperDX dashboard export and notes

### DIFF
--- a/docs/dashboards/coding-agent-model-trends.json
+++ b/docs/dashboards/coding-agent-model-trends.json
@@ -1,0 +1,107 @@
+{
+  "_id": "6a8b6001aeb892a415c3446c",
+  "name": "coding-agent model trends",
+  "tiles": [
+    {
+      "id": "ln-err-hour",
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Error rate % by model (hourly)"
+      }
+    },
+    {
+      "id": "ln-err-5m",
+      "x": 12,
+      "y": 0,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Error rate % by model (5 min)"
+      }
+    },
+    {
+      "id": "ln-tok-hour",
+      "x": 0,
+      "y": 8,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Generation tok/sec by model (hourly)"
+      }
+    },
+    {
+      "id": "ln-tok-5m",
+      "x": 12,
+      "y": 8,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Generation tok/sec by model (5 min)"
+      }
+    },
+    {
+      "id": "ln-lat-hour",
+      "x": 0,
+      "y": 16,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Latency p50/p90/p99 by model (hourly)"
+      }
+    },
+    {
+      "id": "ln-lat-5m",
+      "x": 12,
+      "y": 16,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Latency p50/p90/p99 by model (5 min)"
+      }
+    }
+  ],
+  "team": "69d6f9db842db143c17e053b",
+  "tags": [],
+  "filters": [],
+  "savedFilterValues": [],
+  "containers": [],
+  "createdBy": "69d6f9db842db143c17e0537",
+  "updatedBy": "69d6f9db842db143c17e0537",
+  "provisioned": false,
+  "createdAt": "2026-08-23T21:02:56.883Z",
+  "updatedAt": "2026-08-23T21:02:56.883Z",
+  "__v": 0
+}

--- a/docs/dashboards/coding-agent-model-trends.json
+++ b/docs/dashboards/coding-agent-model-trends.json
@@ -11,7 +11,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Error rate % by model (hourly)"
@@ -26,7 +26,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Error rate % by model (5 min)"
@@ -41,7 +41,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Generation tok/sec by model (hourly)"
@@ -56,7 +56,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Generation tok/sec by model (5 min)"
@@ -71,7 +71,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Latency p50/p90/p99 by model (hourly)"
@@ -86,7 +86,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Latency p50/p90/p99 by model (5 min)"
@@ -95,13 +95,56 @@
   ],
   "team": "69d6f9db842db143c17e053b",
   "tags": [],
-  "filters": [],
+  "filters": [
+    {
+      "id": "flt-model",
+      "type": "QUERY_EXPRESSION",
+      "name": "Model",
+      "expression": "SpanAttributes['gen_ai.request.model']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "model"
+    },
+    {
+      "id": "flt-agent",
+      "type": "QUERY_EXPRESSION",
+      "name": "Client / harness",
+      "expression": "if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName))",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "agent"
+    },
+    {
+      "id": "flt-provider",
+      "type": "QUERY_EXPRESSION",
+      "name": "Provider",
+      "expression": "SpanAttributes['gen_ai.provider.name']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "provider"
+    }
+  ],
   "savedFilterValues": [],
   "containers": [],
   "createdBy": "69d6f9db842db143c17e0537",
   "updatedBy": "69d6f9db842db143c17e0537",
   "provisioned": false,
   "createdAt": "2026-08-23T21:02:56.883Z",
-  "updatedAt": "2026-08-23T21:02:56.883Z",
+  "updatedAt": "2026-08-23T22:12:15.716Z",
   "__v": 0
 }

--- a/docs/dashboards/coding-agent-model-trends.md
+++ b/docs/dashboards/coding-agent-model-trends.md
@@ -56,15 +56,37 @@ not the claude-code ones:
   `<model> · pNN` via
   `arrayZip(['p50','p90','p99'], quantiles(...))` + `ARRAY JOIN`.
 
-## Known limitations
+- **Known limitations:** no percentile dropdown (percentile is baked into the
+  series construction); series count grows with models used (×3 on latency
+  tiles); sparse buckets render as gaps, not zero-filled lines; gen_toks lines
+  are flat-zero for models whose harnesses never set TTFT / `duration_ms`
+  attributes (e.g. codex-only models).
 
-Same as the claude-code trends dashboard:
+## Dashboard filter dropdowns
 
-- **No interactive filters** on raw-SQL tiles; every series renders.
-- **Series count grows with models used** (×3 on the latency tiles).
-- **Sparse buckets render as gaps**, not zero-filled lines.
-- **gen_toks lines are flat-zero** for models whose harnesses never set TTFT /
-  duration_ms attributes (e.g. codex-only models).
+Three variable-enabled dashboard filters render as dropdowns at the top of
+the dashboard: **Model**, **Client / harness**, and **Provider**. Each is a
+`QUERY_EXPRESSION` entry in the doc's `filters` array with
+`isVariableEnabled: true` (`isBroadcastEnabled: false` — filtering happens via
+explicit macros in the tile SQL, not broadcast). Every tile's `sqlTemplate`
+consumes them via `$__filter(<expression>, $<variable>)` macros, which expand
+to `<expression> IN (<selected values>)` when values are picked and to `(1=1)`
+when nothing is selected, so charts stay valid unfiltered.
+
+| filter | variableName | expression | coverage note |
+| --- | --- | --- | --- |
+| Model | `$model` | `SpanAttributes['gen_ai.request.model']` | all canonical spans |
+| Client / harness | `$agent` | `if(SpanAttributes['coding_agent.client.name'] != '', …, if(ServiceName LIKE 'codex%', 'codex', ServiceName))` | same normalization as the metrics dashboard |
+| Provider | `$provider` | `SpanAttributes['gen_ai.provider.name']` | claude_code + codex only — opencode emits no provider attribute, so opencode rows drop out when a provider is selected |
+
+Notes:
+
+- The macro argument parser is quote-aware and paren-counting, so the
+  comma-heavy nested `if()` harness expression parses as a single argument.
+- Expansion was verified with the deployed app's own `replaceMacros`
+  (`common-utils/dist/macros.js`) against all 12 stored templates in both
+  empty and selected states before applying.
+
 
 ## Applying / re-exporting
 

--- a/docs/dashboards/coding-agent-model-trends.md
+++ b/docs/dashboards/coding-agent-model-trends.md
@@ -1,0 +1,107 @@
+# coding-agent model trends (HyperDX dashboard)
+
+Export and notes for the **`coding-agent model trends`** dashboard that lives
+in the HyperDX/ClickStack instance in the `hyperdx` namespace.
+
+- **Live location:** MongoDB `hyperdx` database, `dashboards` collection.
+- **Dashboard `_id`:** `6a8b6001aeb892a415c3446c`
+- **Export snapshot:**
+  [`coding-agent-model-trends.json`](./coding-agent-model-trends.json)
+  (full dashboard document as stored in Mongo).
+- **Data source:** identical criteria to
+  [`coding-agent model metrics`](./coding-agent-model-metrics.md) — canonical
+  connector spans (`SpanName LIKE 'chat %'`,
+  `ResourceAttributes['telemetry.source'] = 'coding-agent'`). Where that
+  dashboard is table/KPI-oriented, this one is time-series only.
+- **Sibling of** [`claude-code model trends`](./claude-code-model-trends.md) —
+  same six-tile line-chart layout, but scoped to all harnesses the
+  [otel-agent-trace-connector](../../../otel-agent-trace-connector.yaml)
+  normalizes instead of native Claude Code spans.
+
+## Tiles
+
+All six tiles are raw-SQL line charts (`displayType: "line"`,
+`configType: "sql"`), paired hourly / 5-minute:
+
+| id | granularity | what it shows |
+| --- | --- | --- |
+| `ln-err-hour` | hourly | error rate % by model |
+| `ln-err-5m` | 5-minute | error rate % by model |
+| `ln-tok-hour` | hourly | generation tok/sec by model |
+| `ln-tok-5m` | 5-minute | generation tok/sec by model |
+| `ln-lat-hour` | hourly | p50/p90/p99 latency (ms) per model × percentile |
+| `ln-lat-5m` | 5-minute | p50/p90/p99 latency (ms) per model × percentile |
+
+## Formula notes (deltas from the claude-code trends dashboard)
+
+The tile SQL follows the coding-agent model metrics dashboard's conventions,
+not the claude-code ones:
+
+- **Error rate counts explicit failures only:** `success = 'false'`, not
+  `!= 'true'` — sources that don't emit `success` would otherwise read as 100%
+  errors.
+- **Latency uses span `Duration`** (nanoseconds, present on every span):
+  `quantiles(0.5, 0.9, 0.99)(Duration)` divided by `1e6`. The
+  `duration_ms` attribute only exists on claude_code spans.
+- **`gen_toks` is guarded** — it returns 0 unless
+  `sum(duration_ms) - sum(ttft_ms) > 0`, so harnesses without TTFT attributes
+  (codex, opencode) don't produce an inflated tokens/sec value; output tokens
+  sum both attribute families (`output_tokens` +
+  `gen_ai.usage.output_tokens`).
+- **Model column:** `gen_ai.request.model`; series dimension is model only
+  (no agent split — that would multiply the line count by harness).
+- Line-chart result shape matches ClickStack's documented contract:
+  timestamp column, series-name column, value column, `GROUP BY <series>, ts`.
+  The latency tile emits one series per model×percentile named
+  `<model> · pNN` via
+  `arrayZip(['p50','p90','p99'], quantiles(...))` + `ARRAY JOIN`.
+
+## Known limitations
+
+Same as the claude-code trends dashboard:
+
+- **No interactive filters** on raw-SQL tiles; every series renders.
+- **Series count grows with models used** (×3 on the latency tiles).
+- **Sparse buckets render as gaps**, not zero-filled lines.
+- **gen_toks lines are flat-zero** for models whose harnesses never set TTFT /
+  duration_ms attributes (e.g. codex-only models).
+
+## Applying / re-exporting
+
+Same procedure as the sibling dashboards: dashboards live in the Mongo replica
+set backing HyperDX; connection string is in secret
+`hyperdx-mongo-app-connection` (namespace `hyperdx`) — do not print it.
+
+```sh
+CONN=$(kubectl get secret -n hyperdx hyperdx-mongo-app-connection \
+  -o jsonpath='{.data.connectionString\.standard}' | base64 -d)
+
+# Export the live dashboard
+kubectl exec -n hyperdx hyperdx-0 -c mongod -i -- \
+  mongosh "$CONN" --quiet --eval \
+  'JSON.stringify(db.getSiblingDB("hyperdx").dashboards.findOne({name:"coding-agent model trends"}), null, 2)'
+```
+
+Edits go against the live document matched by `name`; the `_id` in the export
+is informational. Changes are picked up by the HyperDX app without a restart.
+
+### Gotcha: BSON types on insert
+
+The JSON export is not insertable as-is via `mongosh`. The app stores and
+queries several fields with specific BSON types; if they are inserted as plain
+strings/ISO strings, **the dashboard silently disappears from the UI list**
+(the list query filters `team` by ObjectId, so a string-typed `team` never
+matches). When inserting/updating from a script, cast:
+
+- `team`, `createdBy`, `updatedBy` → `ObjectId(...)`
+- `createdAt`, `updatedAt` → `new Date("...")`
+- include `__v: 0`
+
+Symptom of getting this wrong: `findOne({name: ...})` still returns the doc,
+but it never appears in the dashboards list.
+
+Before applying tile SQL changes, validate them against ClickHouse directly by
+substituting real epoch-milli values for the `{startDateMilliseconds:Int64}` /
+`{endDateMilliseconds:Int64}` placeholders (see
+[`../hyperdx-dashboards.md`](../hyperdx-dashboards.md) for why there is no
+`{timeFilter}` macro in raw-SQL tiles).


### PR DESCRIPTION
## Summary
- Export snapshot + notes for the new `coding-agent model trends` HyperDX dashboard (`6a8b6001aeb892a415c3446c`), sibling of #488's `claude-code model trends`
- Same six-tile line-chart layout (error rate % by model, gen tok/sec by model, p50/p90/p99 latency per model×percentile; hourly + 5-minute pairs) but using the `coding-agent model metrics` dashboard's criteria: canonical connector spans (`SpanName LIKE 'chat %'`, `telemetry.source = 'coding-agent'`)
- Formulas follow the coding-agent conventions: explicit-failure error counting (`success = 'false'`), `Duration`-based latency percentiles, guarded dual-family `gen_toks`

## Live change already applied
The dashboard document was inserted directly into Mongo (upsert matched on name, with correct BSON types per the gotcha documented in this PR's sibling doc) and all six stored `sqlTemplate`s were verified against ClickHouse with real time params.

## Validation
- [x] Each of the 3 SQL shapes verified against ClickHouse before insert, all 6 stored templates re-run with substituted `{startDateMilliseconds}`/`{endDateMilliseconds}` params (250–3123 rows returned)
- [x] Doc re-exported from Mongo matches the committed snapshot; BSON types confirmed (ObjectId team/user fields, Date timestamps, `__v`)
- [ ] Visual check at hyperdx.k8s.somemissing.info (requires UI login)