### PR TITLE
docs: add model/provider filter dropdowns to claude-code trends dashboard

### DIFF
--- a/docs/dashboards/claude-code-model-trends.json
+++ b/docs/dashboards/claude-code-model-trends.json
@@ -11,7 +11,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] != 'true') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Error rate % by model (hourly)"
@@ -26,7 +26,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] != 'true') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Error rate % by model (5 min)"
@@ -41,7 +41,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Generation tok/sec by model (hourly)"
@@ -56,7 +56,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Generation tok/sec by model (5 min)"
@@ -71,7 +71,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(toFloat64OrZero(SpanAttributes['duration_ms']))) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Latency p50/p90/p99 by model (hourly)"
@@ -86,7 +86,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(toFloat64OrZero(SpanAttributes['duration_ms']))) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Latency p50/p90/p99 by model (5 min)"
@@ -95,12 +95,42 @@
   ],
   "team": "69d6f9db842db143c17e053b",
   "tags": [],
-  "filters": [],
+  "filters": [
+    {
+      "id": "flt-model",
+      "type": "QUERY_EXPRESSION",
+      "name": "Model",
+      "expression": "SpanAttributes['gen_ai.request.model']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "model"
+    },
+    {
+      "id": "flt-provider",
+      "type": "QUERY_EXPRESSION",
+      "name": "Provider",
+      "expression": "SpanAttributes['provider.name']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "provider"
+    }
+  ],
   "savedFilterValues": [],
   "containers": [],
   "createdBy": "69d6f9db842db143c17e0537",
   "updatedBy": "69d6f9db842db143c17e0537",
   "provisioned": false,
   "createdAt": "2026-08-23T20:33:40.628Z",
-  "updatedAt": "2026-08-23T20:33:40.628Z"
+  "updatedAt": "2026-08-23T22:12:15.630Z",
+  "__v": 0
 }

--- a/docs/dashboards/claude-code-model-trends.md
+++ b/docs/dashboards/claude-code-model-trends.md
@@ -38,15 +38,40 @@ renders a single group column; it uses
 metrics dashboard:
 `sum(output_tokens) / greatest(sum(duration_ms - ttft_ms), 1) * 1000`.
 
+## Dashboard filter dropdowns
+
+Two variable-enabled dashboard filters render as dropdowns at the top of the
+dashboard: **Model** and **Provider**. Each is a `QUERY_EXPRESSION` entry in
+the doc's `filters` array with `isVariableEnabled: true`
+(`isBroadcastEnabled: false` — filtering happens via explicit macros in the
+tile SQL, not broadcast). Every tile's `sqlTemplate` consumes them via
+`$__filter(<expression>, $<variable>)` macros, which expand to
+`<expression> IN (<selected values>)` when values are picked and to `(1=1)`
+when nothing is selected, so charts stay valid unfiltered.
+
+| filter | variableName | expression | coverage note |
+| --- | --- | --- | --- |
+| Model | `$model` | `SpanAttributes['gen_ai.request.model']` | all spans |
+| Provider | `$provider` | `SpanAttributes['provider.name']` | ~99.8% of spans; reports the API provider (e.g. z.ai), not `gen_ai.system` |
+
+There is no harness dropdown — every span on this dashboard is Claude Code by
+definition.
+
+Expansion was verified with the deployed app's own `replaceMacros`
+(`common-utils/dist/macros.js`) against all 12 stored templates in both empty
+and selected states before applying.
+
 ## Known limitations
 
-- **No interactive filters.** Dashboard-level filters do not inject into
-  raw-SQL tiles, so there is no percentile/model picker; every series renders.
-  To isolate a percentile visually, read the `<model> · pNN` legend entries.
+- **No percentile filter.** The p50/p90/p99 split is baked into series
+  construction, so it can't be a dropdown; isolate percentiles visually via
+  the `<model> · pNN` legend entries.
 - **Series count grows with models used.** Each new `gen_ai.request.model`
   value adds lines to all six tiles (×3 on the latency tiles).
 - **Sparse buckets render as gaps.** Models used intermittently show broken
   lines rather than zero-filled ones.
+- **Provider selection drops unattributed spans.** Spans without
+  `provider.name` (~0.2%) are excluded whenever a provider is picked.
 
 ## Applying / re-exporting
 


### PR DESCRIPTION
## Summary
- Adds **Model** and **Provider** dropdown filters to the `claude-code model trends` dashboard (live doc `6a8b5924aeb892a415c3446b`), replacing the old 'no interactive filters' limitation note
- Filters are variable-enabled `QUERY_EXPRESSION` dashboard filters consumed by every tile's SQL via $__filter macros (expand to `IN (...)` when selected, `(1=1)` when empty)
- Provider uses `SpanAttributes['provider.name']` (reports the actual API provider, e.g. z.ai) rather than `gen_ai.system`
- Refreshed export snapshot; documents the mechanism, coverage caveats, and verification method

## Live change already applied
Both Mongo documents were updated in place (tile `sqlTemplate`s + `filters` arrays); no `_id` or BSON type changes.

## Validation
- [x] Macro expansion verified with the deployed app's own `replaceMacros` (`common-utils/dist/macros.js`) — all 12 templates across both trends dashboards, empty + selected states
- [x] All expanded variants executed against ClickHouse: 24/24 OK, and a coherent selection returns real data (e.g. glm-5.3[1m] × claude_code × anthropic → 1630 rows on the coding-agent dashboard)
- [ ] Visual check of the dropdowns at hyperdx.k8s.somemissing.info (requires UI login)

Sibling change for the coding-agent dashboard is pushed to PR #491.