### PR TITLE
feat: enable HyperDX dashboard filter variables

### DIFF
--- a/application.hyperdx.yaml
+++ b/application.hyperdx.yaml
@@ -75,6 +75,12 @@ spec:
                   secretKeyRef:
                     name: hyperdx-clickstack-config
                     key: mongo-uri
+              # Enables dashboard filter variables ($__filter macros in raw-SQL
+              # tiles). Read at runtime via next-runtime-env; feature is
+              # default-off upstream while it bakes. Without this, unexpanded
+              # $__filter macros reach ClickHouse and every raw-SQL tile errors.
+              - name: NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES
+                value: "true"
           service:
             type: ClusterIP
           ingress:


### PR DESCRIPTION
## Summary
- Sets `NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true` on the HyperDX app deployment
- Required for the model/harness/provider dropdown filters on the two trends dashboards: variable expansion in raw-SQL tiles (`` macros) is gated behind this flag and **default-off upstream** while the feature bakes
- Read at runtime via `next-runtime-env`, so no image rebuild is needed — a pod restart picks it up

## Context
Without the flag, unexpanded ``/`$model` macros reach ClickHouse verbatim (backtick-quoted as identifiers) and every raw-SQL tile errors with ``Unknown expression identifier '$model'``. The feature wiring landed upstream in #2873 (2026-08-13, included in the deployed 2.35.0); only the enable-flag was missing.

## Applied live
`kubectl set env deploy/hyperdx-clickstack-app NEXT_PUBLIC_ENABLE_DASHBOARD_VARIABLES=true -n hyperdx` — this PR reconciles GitOps state with the running cluster.

Also re-applied the dashboard filter definitions to Mongo after reverting them during diagnosis.