### PR TITLE
docs: add coding-agent agent token trends HyperDX dashboard export and notes

### DIFF
--- a/docs/dashboards/coding-agent-agent-token-trends.json
+++ b/docs/dashboards/coding-agent-agent-token-trends.json
@@ -138,7 +138,8 @@
       ],
       "isBroadcastEnabled": false,
       "isVariableEnabled": true,
-      "variableName": "model"
+      "variableName": "model",
+      "where": "SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'"
     },
     {
       "id": "flt-agent",
@@ -152,7 +153,8 @@
       ],
       "isBroadcastEnabled": false,
       "isVariableEnabled": true,
-      "variableName": "agent"
+      "variableName": "agent",
+      "where": "SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'"
     },
     {
       "id": "flt-provider",
@@ -166,7 +168,8 @@
       ],
       "isBroadcastEnabled": false,
       "isVariableEnabled": true,
-      "variableName": "provider"
+      "variableName": "provider",
+      "where": "SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'"
     }
   ],
   "savedFilterValues": [],
@@ -175,6 +178,6 @@
   "updatedBy": "69d6f9db842db143c17e0537",
   "provisioned": false,
   "createdAt": "2026-08-23T23:04:45.052Z",
-  "updatedAt": "2026-08-23T23:04:45.052Z",
+  "updatedAt": "2026-08-23T23:33:37.421Z",
   "__v": 0
 }

--- a/docs/dashboards/coding-agent-agent-token-trends.json
+++ b/docs/dashboards/coding-agent-agent-token-trends.json
@@ -1,0 +1,180 @@
+{
+  "_id": "6a8b7c8daeb892a415c3446d",
+  "name": "coding-agent agent token trends",
+  "tiles": [
+    {
+      "id": "ln-tok-in-hour",
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['input_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.input_tokens'])), 0) AS tok_in FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Input tokens by agent (hourly)"
+      }
+    },
+    {
+      "id": "ln-tok-in-5m",
+      "x": 12,
+      "y": 0,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['input_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.input_tokens'])), 0) AS tok_in FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Input tokens by agent (5 min)"
+      }
+    },
+    {
+      "id": "ln-tok-out-hour",
+      "x": 0,
+      "y": 8,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens'])), 0) AS tok_out FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Output tokens by agent (hourly)"
+      }
+    },
+    {
+      "id": "ln-tok-out-5m",
+      "x": 12,
+      "y": 8,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens'])), 0) AS tok_out FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Output tokens by agent (5 min)"
+      }
+    },
+    {
+      "id": "ln-cache-read-hour",
+      "x": 0,
+      "y": 16,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['cache_read_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.cache_read.input_tokens'])), 0) AS cache_read FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Cache read tokens by agent (hourly)"
+      }
+    },
+    {
+      "id": "ln-cache-read-5m",
+      "x": 12,
+      "y": 16,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['cache_read_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.cache_read.input_tokens'])), 0) AS cache_read FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Cache read tokens by agent (5 min)"
+      }
+    },
+    {
+      "id": "ln-cache-write-hour",
+      "x": 0,
+      "y": 24,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['cache_creation_tokens'])), 0) AS cache_write FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Cache write (creation) tokens by agent (hourly)"
+      }
+    },
+    {
+      "id": "ln-cache-write-5m",
+      "x": 12,
+      "y": 24,
+      "w": 12,
+      "h": 8,
+      "config": {
+        "displayType": "line",
+        "configType": "sql",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)) AS agent, round(sum(toFloat64OrZero(SpanAttributes['cache_creation_tokens'])), 0) AS cache_write FROM otel.otel_traces WHERE SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName)), $agent) AND $__filter(SpanAttributes['gen_ai.provider.name'], $provider) GROUP BY agent, ts ORDER BY ts",
+        "connection": "69d6f9db842db143c17e0540",
+        "source": "69d6f9dc842db143c17e0546",
+        "name": "Cache write (creation) tokens by agent (5 min)"
+      }
+    }
+  ],
+  "team": "69d6f9db842db143c17e053b",
+  "tags": [],
+  "filters": [
+    {
+      "id": "flt-model",
+      "type": "QUERY_EXPRESSION",
+      "name": "Model",
+      "expression": "SpanAttributes['gen_ai.request.model']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "model"
+    },
+    {
+      "id": "flt-agent",
+      "type": "QUERY_EXPRESSION",
+      "name": "Client / harness",
+      "expression": "if(SpanAttributes['coding_agent.client.name'] != '', SpanAttributes['coding_agent.client.name'], if(ServiceName LIKE 'codex%', 'codex', ServiceName))",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "agent"
+    },
+    {
+      "id": "flt-provider",
+      "type": "QUERY_EXPRESSION",
+      "name": "Provider",
+      "expression": "SpanAttributes['gen_ai.provider.name']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "provider"
+    }
+  ],
+  "savedFilterValues": [],
+  "containers": [],
+  "createdBy": "69d6f9db842db143c17e0537",
+  "updatedBy": "69d6f9db842db143c17e0537",
+  "provisioned": false,
+  "createdAt": "2026-08-23T23:04:45.052Z",
+  "updatedAt": "2026-08-23T23:04:45.052Z",
+  "__v": 0
+}

--- a/docs/dashboards/coding-agent-agent-token-trends.md
+++ b/docs/dashboards/coding-agent-agent-token-trends.md
@@ -59,6 +59,13 @@ selected, `(1=1)` when empty). See that doc for details and caveats
 (opencode spans carry no provider attribute and drop out when a provider is
 selected).
 
+Each filter also carries a `where` clause scoping its dropdown value query to
+canonical connector spans (`SpanName LIKE 'chat %' AND
+ResourceAttributes['telemetry.source'] = 'coding-agent'`). Without it, the
+value lookup runs the expression against every span in the database and
+non-connector rows fall through to `ServiceName`, so the harness dropdown
+listed all services in tracing.
+
 ## Known limitations
 
 - **opencode rows are flat zero on all four tiles** — it emits no token

--- a/docs/dashboards/coding-agent-agent-token-trends.md
+++ b/docs/dashboards/coding-agent-agent-token-trends.md
@@ -1,0 +1,92 @@
+# coding-agent agent token trends (HyperDX dashboard)
+
+Export and notes for the **`coding-agent agent token trends`** dashboard that
+lives in the HyperDX/ClickStack instance in the `hyperdx` namespace.
+
+- **Live location:** MongoDB `hyperdx` database, `dashboards` collection.
+- **Dashboard `_id`:** `6a8b7c8daeb892a415c3446d`
+- **Export snapshot:**
+  [`coding-agent-agent-token-trends.json`](./coding-agent-agent-token-trends.json)
+  (full dashboard document as stored in Mongo).
+- **Data source:** same canonical connector spans as
+  [`coding-agent model metrics`](./coding-agent-model-metrics.md) /
+  [`coding-agent model trends`](./coding-agent-model-trends.md) —
+  `SpanName LIKE 'chat %'`,
+  `ResourceAttributes['telemetry.source'] = 'coding-agent'`.
+- **Focus:** total token counts per **agent** (harness) over time — input,
+  output, cache read, and cache write — instead of rates or latency.
+
+## Tiles
+
+Eight raw-SQL line charts (`displayType: "line"`, `configType: "sql"`), four
+metrics × hourly / 5-minute pairs. Series dimension is the normalized agent;
+line-chart result shape matches ClickStack's contract (timestamp column,
+series-name column, value column).
+
+| id | granularity | what it shows |
+| --- | --- | --- |
+| `ln-tok-in-hour` / `ln-tok-in-5m` | hourly / 5-min | input tokens by agent |
+| `ln-tok-out-hour` / `ln-tok-out-5m` | hourly / 5-min | output tokens by agent |
+| `ln-cache-read-hour` / `ln-cache-read-5m` | hourly / 5-min | cache read tokens by agent |
+| `ln-cache-write-hour` / `ln-cache-write-5m` | hourly / 5-min | cache write (creation) tokens by agent |
+
+## Formula notes
+
+Token sums combine both attribute families, matching the sibling dashboards:
+
+- **Input:** `sum(input_tokens) + sum(gen_ai.usage.input_tokens)`
+- **Output:** `sum(output_tokens) + sum(gen_ai.usage.output_tokens)`
+- **Cache read:** `sum(cache_read_tokens) +
+  sum(gen_ai.usage.cache_read.input_tokens)`
+- **Cache write:** `sum(cache_creation_tokens)` only — claude_code is the
+  only harness that emits cache-creation counts; codex has no semconv
+  equivalent and opencode emits no token attributes at all, so both render as
+  flat zero on that tile.
+
+Agent normalization is identical to the metrics dashboard:
+`if(coding_agent.client.name != '', coding_agent.client.name,
+if(ServiceName LIKE 'codex%', 'codex', ServiceName))`.
+
+## Dashboard filter dropdowns
+
+Same three variable-enabled filters as
+[`coding-agent model trends`](./coding-agent-model-trends.md): **Model**
+(`$model`), **Client / harness** (`$agent`), **Provider** (`$provider`) —
+`QUERY_EXPRESSION` entries with `isVariableEnabled: true`,
+`isBroadcastEnabled: false`, consumed by every tile via
+`$__filter(<expression>, $<variable>)` macros (expand to `IN (...)` when
+selected, `(1=1)` when empty). See that doc for details and caveats
+(opencode spans carry no provider attribute and drop out when a provider is
+selected).
+
+## Known limitations
+
+- **opencode rows are flat zero on all four tiles** — it emits no token
+  attributes today; its request volume is visible on the model trends
+  dashboards' error/latency tiles instead.
+- **Cache write is claude_code-only** by data availability.
+- Sparse buckets render as gaps, not zero-filled lines.
+
+## Applying / re-exporting
+
+Same procedure as the sibling dashboards: dashboards live in the Mongo replica
+set backing HyperDX; connection string is in secret
+`hyperdx-mongo-app-connection` (namespace `hyperdx`) — do not print it.
+
+```sh
+CONN=$(kubectl get secret -n hyperdx hyperdx-mongo-app-connection \
+  -o jsonpath='{.data.connectionString\.standard}' | base64 -d)
+
+# Export the live dashboard
+kubectl exec -n hyperdx hyperdx-0 -c mongod -i -- \
+  mongosh "$CONN" --quiet --eval \
+  'JSON.stringify(db.getSiblingDB("hyperdx").dashboards.findOne({name:"coding-agent agent token trends"}), null, 2)'
+```
+
+Edits go against the live document matched by `name`; the `_id` in the export
+is informational. Changes are picked up by the HyperDX app without a restart.
+Observe the BSON-type gotcha documented in
+[`claude-code-model-trends.md`](./claude-code-model-trends.md) when inserting
+from scripts, and validate tile SQL against ClickHouse directly (substituting
+real epoch-milli values for the `{startDateMilliseconds:Int64}` /
+`{endDateMilliseconds:Int64}` placeholders) before applying.


### PR DESCRIPTION
## Summary
- Export snapshot + notes for the new `coding-agent agent token trends` dashboard (`6a8b7c8daeb892a415c3446d`)
- Eight raw-SQL line tiles: total input / output / cache-read / cache-write tokens **by agent** (claude_code, codex, opencode), each at hourly + 5-minute granularity
- Same three filter dropdowns as `coding-agent model trends` (Model / Client-harness / Provider via $__filter macros)
- Token sums combine both attribute families (`*_tokens` + `gen_ai.usage.*`); cache write is claude_code-only since no other harness emits creation counts

## Live change already applied
Dashboard document inserted into Mongo with correct BSON types; all 16 stored-template expansions (8 tiles × empty/selected) verified through the app's own `replaceMacros` and executed against ClickHouse.

## Validation
- [x] All four metric SQL shapes verified against ClickHouse before insert
- [x] 16/16 expanded template variants executed OK; coherent filter selection returns real data (glm-5.3[1m] × claude_code × anthropic → 1630 spans)
- [ ] Visual check at hyperdx.k8s.somemissing.info