### PR TITLE
docs: scope trends dashboard filter dropdown value queries to relevant spans

### DIFF
--- a/docs/dashboards/claude-code-model-trends.json
+++ b/docs/dashboards/claude-code-model-trends.json
@@ -11,7 +11,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] != 'true') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Error rate % by model (hourly)"
@@ -26,7 +26,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] != 'true') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(countIf(SpanAttributes['success'] = 'false') * 100.0 / count(), 2) AS err_pct FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Error rate % by model (5 min)"
@@ -41,7 +41,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Generation tok/sec by model (hourly)"
@@ -56,7 +56,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(sum(toFloat64OrZero(SpanAttributes['output_tokens'])) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY model, ts ORDER BY ts",
+        "sqlTemplate": "SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, round(if(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])) > 0, (sum(toFloat64OrZero(SpanAttributes['output_tokens'])) + sum(toFloat64OrZero(SpanAttributes['gen_ai.usage.output_tokens']))) / greatest(sum(toFloat64OrZero(SpanAttributes['duration_ms'])) - sum(toFloat64OrZero(SpanAttributes['ttft_ms'])), 1) * 1000, 0), 1) AS gen_toks FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY model, ts ORDER BY ts",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Generation tok/sec by model (5 min)"
@@ -71,7 +71,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(toFloat64OrZero(SpanAttributes['duration_ms']))) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfHour(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Latency p50/p90/p99 by model (hourly)"
@@ -86,7 +86,7 @@
       "config": {
         "displayType": "line",
         "configType": "sql",
-        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(toFloat64OrZero(SpanAttributes['duration_ms']))) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
+        "sqlTemplate": "SELECT ts, concat(model, ' \u00b7 ', zp.1) AS series, round(zp.2 / 1e6, 0) AS lat_ms FROM (SELECT toStartOfFiveMinutes(Timestamp) AS ts, SpanAttributes['gen_ai.request.model'] AS model, arrayZip(['p50','p90','p99'], quantiles(0.5, 0.9, 0.99)(Duration)) AS zp FROM otel.otel_traces WHERE SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code' AND Timestamp >= fromUnixTimestamp64Milli({startDateMilliseconds:Int64}) AND Timestamp < fromUnixTimestamp64Milli({endDateMilliseconds:Int64}) AND $__filter(SpanAttributes['gen_ai.request.model'], $model) AND $__filter(SpanAttributes['provider.name'], $provider) GROUP BY ts, model) ARRAY JOIN zp ORDER BY ts, series",
         "connection": "69d6f9db842db143c17e0540",
         "source": "69d6f9dc842db143c17e0546",
         "name": "Latency p50/p90/p99 by model (5 min)"
@@ -95,12 +95,44 @@
   ],
   "team": "69d6f9db842db143c17e053b",
   "tags": [],
-  "filters": [],
+  "filters": [
+    {
+      "id": "flt-model",
+      "type": "QUERY_EXPRESSION",
+      "name": "Model",
+      "expression": "SpanAttributes['gen_ai.request.model']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "model",
+      "where": "SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code'"
+    },
+    {
+      "id": "flt-provider",
+      "type": "QUERY_EXPRESSION",
+      "name": "Provider",
+      "expression": "SpanAttributes['provider.name']",
+      "source": "69d6f9dc842db143c17e0546",
+      "whereLanguage": "sql",
+      "appliesToSourceIds": [
+        "69d6f9dc842db143c17e0546"
+      ],
+      "isBroadcastEnabled": false,
+      "isVariableEnabled": true,
+      "variableName": "provider",
+      "where": "SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code'"
+    }
+  ],
   "savedFilterValues": [],
   "containers": [],
   "createdBy": "69d6f9db842db143c17e0537",
   "updatedBy": "69d6f9db842db143c17e0537",
   "provisioned": false,
   "createdAt": "2026-08-23T20:33:40.628Z",
-  "updatedAt": "2026-08-23T20:33:40.628Z"
+  "updatedAt": "2026-08-23T23:33:37.449Z",
+  "__v": 0
 }

--- a/docs/dashboards/claude-code-model-trends.md
+++ b/docs/dashboards/claude-code-model-trends.md
@@ -38,6 +38,14 @@ renders a single group column; it uses
 metrics dashboard:
 `sum(output_tokens) / greatest(sum(duration_ms - ttft_ms), 1) * 1000`.
 
+Each filter also carries a `where` clause scoping its dropdown value query to
+the relevant spans (`SpanName LIKE 'chat %' AND
+ResourceAttributes['telemetry.source'] = 'coding-agent'` on the coding-agent
+dashboards, `SpanName = 'claude_code.llm_request' AND ServiceName =
+'claude-code'` on the claude-code one). Without it, the value lookup runs the
+expression against every span in the database and non-connector rows fall
+through to `ServiceName`, so the harness dropdown listed all services.
+
 ## Known limitations
 
 - **No interactive filters.** Dashboard-level filters do not inject into

--- a/docs/dashboards/coding-agent-model-trends.json
+++ b/docs/dashboards/coding-agent-model-trends.json
@@ -108,7 +108,8 @@
       ],
       "isBroadcastEnabled": false,
       "isVariableEnabled": true,
-      "variableName": "model"
+      "variableName": "model",
+      "where": "SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'"
     },
     {
       "id": "flt-agent",
@@ -122,7 +123,8 @@
       ],
       "isBroadcastEnabled": false,
       "isVariableEnabled": true,
-      "variableName": "agent"
+      "variableName": "agent",
+      "where": "SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'"
     },
     {
       "id": "flt-provider",
@@ -136,7 +138,8 @@
       ],
       "isBroadcastEnabled": false,
       "isVariableEnabled": true,
-      "variableName": "provider"
+      "variableName": "provider",
+      "where": "SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'"
     }
   ],
   "savedFilterValues": [],
@@ -145,6 +148,6 @@
   "updatedBy": "69d6f9db842db143c17e0537",
   "provisioned": false,
   "createdAt": "2026-08-23T21:02:56.883Z",
-  "updatedAt": "2026-08-23T22:12:15.716Z",
+  "updatedAt": "2026-08-23T23:33:37.381Z",
   "__v": 0
 }

--- a/docs/dashboards/coding-agent-model-trends.md
+++ b/docs/dashboards/coding-agent-model-trends.md
@@ -127,3 +127,13 @@ substituting real epoch-milli values for the `{startDateMilliseconds:Int64}` /
 `{endDateMilliseconds:Int64}` placeholders (see
 [`../hyperdx-dashboards.md`](../hyperdx-dashboards.md) for why there is no
 `{timeFilter}` macro in raw-SQL tiles).
+
+## Filter value-query scope
+
+Each filter also carries a `where` clause scoping its dropdown value query to
+the relevant spans (`SpanName LIKE 'chat %' AND
+ResourceAttributes['telemetry.source'] = 'coding-agent'` on the coding-agent
+dashboards, `SpanName = 'claude_code.llm_request' AND ServiceName =
+'claude-code'` on the claude-code one). Without it, the value lookup runs the
+expression against every span in the database and non-connector rows fall
+through to `ServiceName`, so the harness dropdown listed all services.


### PR DESCRIPTION
## Summary
- Adds `where` clauses to the dashboard-filter definitions on both trends dashboards so their dropdown **value lookups** are scoped to the relevant spans:
  - coding-agent dashboards: `SpanName LIKE 'chat %' AND ResourceAttributes['telemetry.source'] = 'coding-agent'`
  - claude-code dashboard: `SpanName = 'claude_code.llm_request' AND ServiceName = 'claude-code'`
- Without it, the dropdown value query evaluates the filter expression against every span in the database; rows outside the connector output fall through the harness expression to `ServiceName`, so the Client/harness dropdown listed every service in tracing

## Live change already applied
All three dashboards' `filters[].where` updated in Mongo. Verified: scoped DISTINCT of the harness expression returns exactly `claude_code`, `codex`, `opencode`; the unscoped query returns the full service list (argocd-*, envoy, hdx-oss-api, …) — matching the reported symptom.

The agent-token-trends doc update is pushed to PR #495's branch since its base file isn't on main yet.