### PR TITLE
feat: block drain eviction of running cukk upgrade pods

### DIFF
--- a/cukk.yaml
+++ b/cukk.yaml
@@ -132,3 +132,21 @@ roleRef:
   kind: ClusterRole
   name: cukk
   apiGroup: rbac.authorization.k8s.io
+---
+# Protect running cukk upgrade Job pods from voluntary eviction (kubectl
+# drain, node maintenance): the pods run privileged against the host and an
+# eviction mid-`apt-get install` leaves dpkg interrupted on the node, which
+# blocks all further upgrades. maxUnavailable: 0 counts only running pods,
+# so when no upgrade is in flight the budget is unsatisfied-by-absence and
+# drains of the node are unaffected. The operator pod (app: cukk) does not
+# match this selector and stays evictable.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cukk-upgrade-pods
+  namespace: kube-system
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      cukk.io/managed-by: cukk


### PR DESCRIPTION
Adds a PodDisruptionBudget (`maxUnavailable: 0`) selecting `cukk.io/managed-by: cukk` so a running cukk upgrade Job pod cannot be evicted by `kubectl drain` or any other voluntary disruption while it chroots into the node and runs apt/kubeadm.

## Why

An upgrade pod evicted mid-`apt-get install` leaves dpkg interrupted on the host (kubeadm half-installed), which fails every later upgrade attempt on that node with `E: dpkg was interrupted` until repaired by hand. This happened on `vmubtkube-a02` during the 1.36.4 wave when a concurrent operator reconcile drained the node seconds after creating the upgrade pod — see the root-cause writeup in nijave/cukk#2, which fixes the operator-side race.

## Behavior notes

- The selector matches only upgrade Job pods. The operator deployment pod (`app: cukk`) is not matched and stays evictable.
- PDBs ignore Succeeded/Failed pods, so completed Job pods lingering on the node never block a drain; the budget only bites while a pod is actively upgrading.
- The operator's own drain runs before it creates any upgrade pod, so its flow is unaffected — this only rejects drains that would hit a live upgrade.