### PR TITLE
chore(deps): update registry.apps.nickv.me/nijave/cukk digest to dcc94da4

### DIFF
--- a/cukk.yaml
+++ b/cukk.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: operator
           # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/nijave/cukk
-          image: registry.apps.nickv.me/nijave/cukk:latest@sha256:8d753f40805e73990c33cf5f2cc6b24aae6d5eb37bffcd6b40faa114d90d0039
+          image: registry.apps.nickv.me/nijave/cukk:latest@sha256:dcc94da49887cff7e9f158a4d4f4e65ff47cbcac3f6cf7c87821e0086d409fae
           imagePullPolicy: Always
           ports:
             - containerPort: 9090


### PR DESCRIPTION
## What

Bump the cukk image to `dcc94da4` — the CI build from cukk main @ `0cc60c9`, whose lock pairs **kopf 1.44.6** with kubernetes-client 36.0.3. Jumping ahead of renovate's next digest PR because the operator is down.

## Why

Renovate's #515 shipped `8d753f40`, built from an intermediate cukk main state (between the kubernetes-36 bump and the lock-file-maintenance merge) that paired **kubernetes-client 36.0.3** with **kopf 1.44.1**. ArgoCD synced it at 23:34 UTC and cukk has been in CrashLoopBackOff since:

- v36 renamed the in-cluster bearer-token storage from `api_key['authorization']` to `api_key['BearerToken']` ([kubernetes-client/python#2582](https://github.com/kubernetes-client/python/issues/2582))
- kopf 1.44.1's `login_via_client` reads only the old key ([kopf#1307](https://github.com/nolar/kopf/issues/1307)) → `ConnectionInfo(token=None)` → API session with no `Authorization` header → every request as `system:anonymous` → 403 on `/api`/`/apis` → operator exits
- kopf 1.44.6 reads both key locations; its image (`dcc94da4`, built 23:42 UTC, eight minutes after the broken pod started) is already in the registry

Not RBAC, not the ServiceAccount — `system:anonymous` on a discovery endpoint means no credentials were presented at all.

## Verification

Ran kopf's actual `login_via_client` with a simulated in-cluster env inside both images:

| image | kopf / kubernetes | extracted token |
|---|---|---|
| `8d753f40` (deployed, crash-looping) | 1.44.1 / 36.0.3 | `None` |
| `dcc94da4` (this PR) | 1.44.6 / 36.0.3 | token extracted |

Merging lets ArgoCD roll cukk onto the fixed image. A regression test for the cukk repo itself (CI canary for this dependency pairing) is being prepared separately in nijave/cukk.