### PR TITLE
fix(argocd): honor ignore-healthcheck on PDBs during sync

### DIFF
--- a/application.argocd.yaml
+++ b/application.argocd.yaml
@@ -122,6 +122,45 @@ spec:
                 hs.message = "Waiting for status"
               end
               return hs
+            # PodDisruptionBudgets that select Job pods (cukk-upgrade-pods in
+            # kube-system, see cukk.yaml) are permanently DisruptionAllowed=False
+            # / reason=SyncFailed because jobs.batch does not implement the
+            # scale subresource, so the disruption controller can never compute
+            # a budget while cukk's retained (terminal) upgrade Job pods exist.
+            # The built-in PDB health check maps that to Degraded, and the sync
+            # operation's post-apply health assessment fails the whole root-app
+            # sync on it -- the ignore-healthcheck annotation alone only covers
+            # app-health aggregation, not the sync wait
+            # (argoproj/argo-cd#22940, still open). This override makes the
+            # annotation also short-circuit the health assessment used during
+            # sync; PDBs without the annotation keep the exact built-in
+            # behavior (replicated below from ArgoCD v3.5.2 -- re-sync this
+            # copy if the built-in check ever changes upstream).
+            resource.customizations.health.policy_PodDisruptionBudget: |
+              hs = {}
+              if obj.metadata ~= nil and obj.metadata.annotations ~= nil and obj.metadata.annotations["argocd.argoproj.io/ignore-healthcheck"] == "true" then
+                hs.status = "Healthy"
+                hs.message = "Health ignored by annotation"
+                return hs
+              end
+              hs.status = "Progressing"
+              hs.message = "Waiting for status"
+              if obj.status ~= nil then
+                if obj.status.conditions ~= nil then
+                  for i, condition in ipairs(obj.status.conditions) do
+                    -- InsufficientPods can have valid use cases
+                    if condition.status == "False" and condition.reason ~= "InsufficientPods" then
+                      hs.status = "Degraded"
+                      hs.message = "PodDisruptionBudget has " .. condition.reason
+                      return hs
+                    else
+                      hs.status = "Healthy"
+                      hs.message = "PodDisruptionBudget has " .. condition.reason
+                    end
+                  end
+                end
+              end
+              return hs
             resource.customizations.health.volsync.backube_ReplicationSource: |
               hs = {}
               if obj.status ~= nil then


### PR DESCRIPTION
## Context

The root-app sync operation has been reporting Failed since 2026-08-28 11:05Z: the post-apply health assessment marks `PodDisruptionBudget/cukk-upgrade-pods` Degraded (`SyncFailed`, because `jobs.batch` lacks the scale subresource while cukk's retained upgrade Job pods exist), which fails the whole operation on every attempt. `argocd.argoproj.io/ignore-healthcheck` only skips app-health aggregation, not the sync wait ([argoproj/argo-cd#22940](https://github.com/argoproj/argo-cd/issues/22940), still open).

## Change

Custom Lua health check for `policy/PodDisruptionBudget` in `argocd-cm`: when the object carries the `ignore-healthcheck` annotation, return Healthy; otherwise replicate the built-in v3.5.2 check exactly (including the `InsufficientPods` carve-out), so every other PDB keeps identical behavior. Verified the script against five cases locally, including the live cukk condition (`SyncFailed` + `jobs.batch does not implement the scale subresource`).

## Rollout note

Expect the merge's own root-app sync to still report Failed one last time — the failing health task applies everything anyway, so `argocd-cm` lands, the controller picks up the override, and subsequent syncs go green.