### PR TITLE
Accept OTLP metrics on agents collector, remote-write to Thanos

### DIFF
--- a/docs/coding-agent-traces.md
+++ b/docs/coding-agent-traces.md
@@ -19,17 +19,20 @@ invoke_agent <agent>
   connector preserves that hierarchy and renames spans/attributes into the same
   vocabulary.
 
-Raw vendor telemetry is forwarded **in parallel, unmodified**, so the original
-Codex logs and Claude Code spans stay queryable in HyperDX alongside the
-canonical traces.
+The collector forwards raw vendor telemetry **in parallel, unmodified**, so
+the original Codex logs and Claude Code spans stay queryable in HyperDX
+alongside the canonical traces.
 
 ## Where it sits
 
 ```text
 Codex / Claude Code
   └─ agents-otel.k8s.somemissing.info:4317 (gRPC) / :4318 (HTTP)   [this service]
-       └─ otel-collector.k8s.somemissing.info:4317                 [monitoring]
-            └─ hyperdx-otel-collector.hyperdx:4317 → ClickHouse
+       ├─ logs + traces
+       │    └─ otel-collector.k8s.somemissing.info:4317            [monitoring]
+       │         └─ hyperdx-otel-collector.hyperdx:4317 → ClickHouse
+       └─ metrics
+            └─ thanos-receive-router.thanos.svc:19291 (remote write) → Thanos
 ```
 
 The second hop is the same collector `projectcontour`'s `otel-collector`
@@ -40,26 +43,29 @@ forwards to.
 TLS is a public Let's Encrypt cert (DNS-01), so no CA needs trusting. The
 hostname is LAN-only — see "DNS zones and TLS" in the [README](../README.md).
 
-> **Use the signal-specific endpoint variables.** This collector serves logs
-> and traces only. The downstream `otel-collector` sets `metrics: null`, so the
-> cluster does not ingest OTLP metrics at all — a generic
-> `OTEL_EXPORTER_OTLP_ENDPOINT` will fail on the metrics service. Set
-> `OTEL_METRICS_EXPORTER=none`.
+> **This collector accepts all three signals.** Logs and traces go to the
+> downstream `otel-collector`; metrics take a separate path into Thanos
+> Receive via remote write (the downstream collector still sets
+> `metrics: null`, which preserves that contract). A generic
+> `OTEL_EXPORTER_OTLP_ENDPOINT` now works for every signal; the
+> signal-specific variables below are the more explicit option.
 
 Claude Code — native trace export is still beta and off by default:
 
 ```bash
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
-export OTEL_METRICS_EXPORTER=none
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://agents-otel.k8s.somemissing.info:4318/v1/metrics
 export OTEL_TRACES_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://agents-otel.k8s.somemissing.info:4318/v1/traces
 ```
 
-Claude Code's *logs* carry prompt/tool content when the `OTEL_LOG_*` content
-gates are enabled; leave them unset. Its traces are what the connector
-normalizes.
+Claude Code's *logs* carry prompt/tool content when you enable the
+`OTEL_LOG_*` content gates; leave them unset. Its traces are what the
+connector normalizes.
 
 Codex reads **user-level** `~/.codex/config.toml` only — it ignores
 project-local `[otel]` blocks (it warns and drops an `otel` key found in a
@@ -71,6 +77,7 @@ environment = "production"
 log_user_prompt = false
 exporter       = { otlp-grpc = { endpoint = "https://agents-otel.k8s.somemissing.info:4317" } }
 trace_exporter = { otlp-grpc = { endpoint = "https://agents-otel.k8s.somemissing.info:4317" } }
+metrics_exporter = { otlp-grpc = { endpoint = "https://agents-otel.k8s.somemissing.info:4317" } }
 ```
 
 `otel.exporter` is the **logs** exporter and defaults to `"none"`. Codex emits
@@ -82,12 +89,12 @@ Claude edge drops any resource that has no `claude_code.`-prefixed span, so
 there is no duplication), but pointing it at this collector still gets those
 spans the 100% sampling exemption.
 
-`metrics_exporter` defaults to Statsig rather than OTLP, so the metrics caveat
-above does not apply to Codex unless you set it explicitly.
+`metrics_exporter` defaults to Statsig rather than OTLP; set it like
+`exporter` above to route Codex metrics through this collector into Thanos.
 
 Keep `log_user_prompt = false`. The connector never copies prompt text, tool
-arguments, or tool output into generated spans, but the **raw** Codex logs are
-forwarded verbatim, so anything Codex logs does reach ClickHouse.
+arguments, or tool output into generated spans, but it forwards the **raw**
+Codex logs verbatim, so anything Codex logs does reach ClickHouse.
 
 ## Sampling
 
@@ -104,10 +111,10 @@ If you add another hop between here and HyperDX, it needs the same exemption.
 - **Single replica, `strategy: Recreate`** — deliberate. Codex turn correlation
   is in-memory; two replicas would split one turn's log records into two
   incomplete traces. The state does not survive a restart, so a roll or a crash
-  drops in-flight turns. Completed traces are unaffected.
-- `max_active_turns: 500` bounds that state. Turns finalize on a quiet
+  drops in-flight turns. Completed traces survive both.
+- `max_active_turns: 500` bounds that state. Turns close on a quiet
   `reorder_window` (30s) after `response.completed`, or at `turn_timeout` (10m).
 - The connector is at **development stability** upstream; span names and
   attributes may change between releases.
-- The image tag is pinned and Renovate-tracked. Releases are cut by tagging the
-  upstream repo, which publishes `ghcr.io/nijave/otel-agent-trace-connector`.
+- Renovate tracks the pinned image tag. Tagging the upstream repo cuts each
+  release and publishes `ghcr.io/nijave/otel-agent-trace-connector`.

--- a/otel-agent-trace-connector-alerts.yaml
+++ b/otel-agent-trace-connector-alerts.yaml
@@ -41,21 +41,37 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: AgentTraceConnectorMetricsExportFailures
+      annotations:
+        summary: "Coding-agent trace connector is failing to send metrics to Thanos Receive."
+        description: >-
+          The prometheusremotewrite exporter is failing to deliver metric
+          points to thanos-receive-router. Retries absorb transient errors,
+          but once the sending queue fills the points are dropped for good,
+          and non-retryable 4xx rejections drop immediately. Check the pod
+          logs for the exporter error and that thanos-receive-router.thanos
+          is reachable and its ingestors healthy.
+      expr: sum by (exporter) (rate(otelcol_exporter_send_failed_metric_points[10m])) > 0
+      for: 5m
+      labels:
+        severity: warning
     - alert: AgentTraceConnectorIngestRejections
       annotations:
         summary: "Coding-agent trace connector is refusing or failing inbound telemetry."
         description: >-
-          The otlp receiver rejected spans or log records instead of accepting
-          them -- refused means the client's request bounced (TLS, auth,
-          size), failed means it was accepted then errored inside the
-          pipeline. Agents usually surface this as their own OTLP exporter
-          errors, but headless runs may not. Compare
+          The otlp receiver rejected spans, log records, or metric points
+          instead of accepting them -- refused means the client's request
+          bounced (TLS, auth, size), failed means it was accepted then
+          errored inside the pipeline. Agents usually surface this as their
+          own OTLP exporter errors, but headless runs may not. Compare
           otelcol_receiver_accepted_* against otelcol_receiver_refused_* /
           _failed_* for the affected signal.
       expr: sum(rate(otelcol_receiver_refused_spans[10m])) +
             sum(rate(otelcol_receiver_refused_log_records[10m])) +
+            sum(rate(otelcol_receiver_refused_metric_points[10m])) +
             sum(rate(otelcol_receiver_failed_spans[10m])) +
-            sum(rate(otelcol_receiver_failed_log_records[10m])) > 0
+            sum(rate(otelcol_receiver_failed_log_records[10m])) +
+            sum(rate(otelcol_receiver_failed_metric_points[10m])) > 0
       for: 5m
       labels:
         severity: warning

--- a/otel-agent-trace-connector.yaml
+++ b/otel-agent-trace-connector.yaml
@@ -102,6 +102,17 @@ data:
         endpoint: otel-collector.k8s.somemissing.info:4317
         tls:
           insecure: false
+      # Metrics diverge from the logs/traces path: instead of the second hop
+      # to otel-collector (which keeps `metrics: null`), remote-write straight
+      # to Thanos Receive -- the same URL kube-prometheus-stack and
+      # prometheus-ext use; the receive router has no auth.
+      prometheusremotewrite:
+        endpoint: http://thanos-receive-router.thanos.svc.cluster.local.:19291/api/v1/receive
+        # Resource attrs as labels: without this, claude-code/codex series are
+        # indistinguishable in Thanos (service.name) and the coding-agent tag
+        # (telemetry.source) never arrives.
+        resource_to_telemetry_conversion:
+          enabled: true
 
     service:
       extensions: [health_check]
@@ -130,13 +141,16 @@ data:
           receivers: [coding_agent, coding_agent/claude]
           processors: [resource/coding_agent, batch]
           exporters: [otlp_grpc]
-        # No metrics pipeline, deliberately: the downstream otel-collector sets
-        # `metrics: null`, so this cluster does not ingest OTLP metrics at all
-        # (the claude-code dashboards are built from otel_traces). Agents must
-        # therefore use the signal-specific OTEL_EXPORTER_OTLP_*_ENDPOINT
-        # variables, or set OTEL_METRICS_EXPORTER=none -- a generic endpoint
-        # pointed here will fail on the metrics service. See
-        # docs/coding-agent-traces.md.
+        # OTLP metrics ride the same receiver as logs/traces but remote-write
+        # to Thanos instead of forwarding to otel-collector (whose
+        # `metrics: null` stands, so the downstream contract is unchanged).
+        # Agent metric volume is low; `batch` is reused as-is -- its 16/64
+        # sizing was tuned for the 4 MiB gRPC hop, which this HTTP export is
+        # not subject to.
+        metrics/agents:
+          receivers: [otlp]
+          processors: [resource/coding_agent, batch]
+          exporters: [prometheusremotewrite]
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -166,7 +180,7 @@ spec:
       containers:
         - name: collector
           # renovate: datasource=docker depName=ghcr.io/nijave/otel-agent-trace-connector
-          image: ghcr.io/nijave/otel-agent-trace-connector:v0.5.0
+          image: ghcr.io/nijave/otel-agent-trace-connector:v0.6.0
           imagePullPolicy: IfNotPresent
           args: ["--config=/conf/config.yaml"]
           ports:


### PR DESCRIPTION
## What

`agents-otel` now accepts OTLP **metrics** on the same receiver as logs and
traces (OTLP gRPC/HTTP + TLS, no agent-side change needed beyond pointing a
metrics exporter at it). Instead of the second hop to `otel-collector` — whose
`metrics: null` contract stands — metrics remote-write directly to Thanos
Receive at `thanos-receive-router.thanos.svc:19291`, the same endpoint
kube-prometheus-stack and prometheus-ext already use.

- `resource_to_telemetry_conversion` promotes resource attrs to labels, so
  `service_name` distinguishes claude-code/codex series and the
  `telemetry_source=coding-agent` tag survives. Trade-off: all resource attrs
  become labels (`service.instance.id` varies per agent session) — accepted at
  homelab volume.
- New alert `AgentTraceConnectorMetricsExportFailures`
  (`otelcol_exporter_send_failed_metric_points`) plus metric-point terms in the
  ingest-rejection rule — metrics drops would otherwise be invisible while
  scrape `up == 1`, the same silent class as the 2026-08-23 incident.
- `docs/coding-agent-traces.md`: a generic `OTEL_EXPORTER_OTLP_ENDPOINT` now
  works for every signal; Claude Code / Codex examples updated. A few
  incidental prose fixes for the Vale hook ride along in that file.

## Rollout ordering — do not merge early

⚠️ Depends on nijave/otel-agent-trace-connector#73 (bundles the
`prometheusremotewrite` exporter). Merge that, push tag **v0.6.0** to publish
`ghcr.io/nijave/otel-agent-trace-connector:v0.6.0`, **then** merge this. The
new config references the exporter; against the pinned v0.5.0 image the
collector fails config load and takes logs/traces ingest down with it.

The embedded collector config validates against the rebuilt v0.6.0 dist binary
(`otelcol-coding-agents validate`).

## Post-deploy check

`otelcol_receiver_accepted_metric_points > 0` and
`otelcol_exporter_send_failed_metric_points == 0` on the pod's :8888, and a
test series visible in Thanos Query carrying `telemetry_source="coding-agent"`.
