### PR TITLE
Monitor mail01: node-exporter scrape, TLS probes, mail-stack alerts

### DIFF
--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -69,6 +69,22 @@ spec:
             - name: smtp.somemissing.info
               url: smtp.somemissing.info:25
               module: smtp_starttls
+            # Email TLS-only listeners, probed on the internal FQDN: the
+            # router forwards only 25/143 to the public edge (587/993/995/
+            # 4190 time out from outside, verified 2026-09-01), so these
+            # check the services themselves rather than the edge.
+            - name: mail01-submission-587
+              url: vmubt1604mail01.homelab.somemissing.info:587
+              module: smtp_starttls
+            - name: mail01-imaps-993
+              url: vmubt1604mail01.homelab.somemissing.info:993
+              module: imaps_banner
+            - name: mail01-pop3s-995
+              url: vmubt1604mail01.homelab.somemissing.info:995
+              module: pop3s_banner
+            - name: mail01-sieve-4190
+              url: vmubt1604mail01.homelab.somemissing.info:4190
+              module: sieve_banner
             # Web (HTTP)
             - name: nickv.me
               url: https://nickv.me
@@ -171,6 +187,26 @@ spec:
                   - send: "EHLO prober\r"
                   - expect: "^250-AUTH"
                   - send: "QUIT\r"
+            imaps_banner:
+              prober: tcp
+              timeout: 5s
+              tcp:
+                tls: true
+                query_response:
+                  - expect: "^\\* OK"
+            pop3s_banner:
+              prober: tcp
+              timeout: 5s
+              tcp:
+                tls: true
+                query_response:
+                  - expect: "^\\+OK"
+            sieve_banner:
+              prober: tcp
+              timeout: 5s
+              tcp:
+                query_response:
+                  - expect: "^IMPLEMENTATION"
             irc_banner:
               prober: tcp
               timeout: 5s
@@ -201,14 +237,6 @@ spec:
                 preferred_ip_protocol: "ip4"
             tcp_connect:
               prober: tcp
-            pop3s_banner:
-              prober: tcp
-              tcp:
-                query_response:
-                - expect: "^+OK"
-                tls: true
-                tls_config:
-                  insecure_skip_verify: false
             grpc:
               prober: grpc
               grpc:

--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -69,19 +69,20 @@ spec:
             - name: smtp.somemissing.info
               url: smtp.somemissing.info:25
               module: smtp_starttls
-            # Email TLS-only listeners, probed on the internal FQDN: the
-            # router forwards only 25/143 to the public edge (587/993/995/
-            # 4190 time out from outside, verified 2026-09-01), so these
-            # check the services themselves rather than the edge.
-            - name: mail01-submission-587
-              url: vmubt1604mail01.homelab.somemissing.info:587
+            # Email TLS-only listeners. Submission 587 and POP3S 995 are
+            # forwarded at the public edge (verified from an external host
+            # 2026-09-01) and probed there like 25/143; IMAPS 993 and
+            # ManageSieve 4190 are not forwarded, so they are probed on the
+            # internal FQDN as service checks only.
+            - name: smtp.somemissing.info:587
+              url: smtp.somemissing.info:587
               module: smtp_starttls
+            - name: imap.somemissing.info:995
+              url: imap.somemissing.info:995
+              module: pop3s_banner
             - name: mail01-imaps-993
               url: vmubt1604mail01.homelab.somemissing.info:993
               module: imaps_banner
-            - name: mail01-pop3s-995
-              url: vmubt1604mail01.homelab.somemissing.info:995
-              module: pop3s_banner
             - name: mail01-sieve-4190
               url: vmubt1604mail01.homelab.somemissing.info:4190
               module: sieve_banner

--- a/mail01-alerts.yaml
+++ b/mail01-alerts.yaml
@@ -1,0 +1,90 @@
+# Mail-stack alerts for vmubt1604mail01 (smtp.somemissing.info), evaluated
+# by the `ext` Prometheus (ruleSelector matchLabels prometheus: ext).
+#
+# - Queue metrics come from the postfix-queue-metrics textfile collector on
+#   the host (cron writes postfix_queue.prom under
+#   /var/lib/prometheus/node-exporter every 5m; source of truth lives in the
+#   infra workspace under hosts/vmubt1604mail01/), exposed via the
+#   node-exporter scrape target added in the same PR.
+# - Unit-state metrics ride node-exporter's systemd collector, which the
+#   Ubuntu package enables by default; postfix runs as the instance unit
+#   postfix@-.service (postfix.service is the oneshot wrapper).
+# - Mail01NodeExporterAbsent covers the gap scrape-failure-alerts.yaml
+#   documents: up == 0 cannot fire for a target that vanished from the
+#   scrape config. It is absent-only, so ScrapeFailed keeps owning the
+#   reachable-but-failing case without double-alerting.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mail01-alerts
+  namespace: monitoring
+  labels:
+    prometheus: ext
+spec:
+  groups:
+  - name: mail01
+    rules:
+    - alert: MailServiceUnitDown
+      annotations:
+        summary: Mail-stack unit {{ $labels.name }} on mail01 has not been active for 5 minutes.
+        description: >-
+          {{ $labels.name }} on vmubt1604mail01 reports no active state via
+          node-exporter's systemd collector (covers postfix@-, dovecot,
+          opendkim, opendmarc, postgrey, and spamassassin). Check
+          'systemctl status {{ $labels.name }}' and 'journalctl -u
+          {{ $labels.name }}' on the host.
+      expr: |-
+        node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name=~"(postfix@-|dovecot|opendkim|opendmarc|postgrey|spamassassin)\.service",
+          state="active"
+        } == 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: MailQueueBacklog
+      annotations:
+        summary: Postfix queue on mail01 holds over 100 messages for an hour.
+        description: >-
+          Total across all queues exceeds 100 for 1h. Run 'postqueue -p' on
+          vmubt1604mail01; 'postcat -q <id>' shows why a message is stuck,
+          and 'postsuper -d ALL deferred' clears junk from the deferred queue.
+      expr: |-
+        sum(postfix_queue_messages{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100"
+        }) > 100
+      for: 1h
+      labels:
+        severity: warning
+    - alert: MailDeferredQueueStuck
+      annotations:
+        summary: Postfix deferred queue on mail01 has held 20+ messages for a day.
+        description: >-
+          Deferred messages retry for ~5 days before bouncing, so 20+ parked
+          for 24h means a pile-up: dead remote, DNS failure, or outbound
+          blocking. Inspect with 'postqueue -p' and 'postcat -q' on
+          vmubt1604mail01.
+      expr: |-
+        postfix_queue_messages{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          queue="deferred"
+        } > 20
+      for: 24h
+      labels:
+        severity: warning
+    - alert: Mail01NodeExporterAbsent
+      annotations:
+        summary: The mail01 node-exporter target is absent from the ext Prometheus.
+        description: >-
+          up{job="node-exporter", instance="vmubt1604mail01...:9100"} has no
+          series, so the target was removed or renamed in prometheus-ext.yaml
+          (ScrapeFailed cannot fire for a vanished job; ScrapeFailed owns the
+          reachable-but-failing case).
+      expr: |-
+        absent(up{
+          job="node-exporter",
+          instance="vmubt1604mail01.homelab.somemissing.info:9100"
+        })
+      for: 15m
+      labels:
+        severity: warning

--- a/node-filesystem-alerts.yaml
+++ b/node-filesystem-alerts.yaml
@@ -1,6 +1,6 @@
 # Node filesystem space alerts for the external node-exporter hosts, evaluated
 # by the `ext` Prometheus (ruleSelector matchLabels prometheus: ext) over its
-# six static node-exporter targets. The kube-prometheus-stack Prometheus
+# seven static node-exporter targets. The kube-prometheus-stack Prometheus
 # already ships the same alerts from the chart's bundled kubernetes-mixin rules
 # (prom-kp-node-exporter), so this file exists only for the ext hosts; the
 # expressions are kept identical to the mixin so both instances behave the

--- a/prometheus-ext.yaml
+++ b/prometheus-ext.yaml
@@ -106,6 +106,7 @@ stringData:
         - vmcent74docker.homelab.somemissing.info:9100
         - vmcent74web02.homelab.somemissing.info:9100
         - vmcentelk01.homelab.somemissing.info:9100
+        - vmubt1604mail01.homelab.somemissing.info:9100
         - vmubt1804mysql01.homelab.somemissing.info:9100
     - job_name: ubthv01
       scrape_interval: 10s


### PR DESCRIPTION
## What

Brings vmubt1604mail01 (smtp/imap.somemissing.info) under Prometheus monitoring in three layers:

- **Host metrics**: seventh static target in the ext Prometheus `node-exporter` job. `node-filesystem-alerts-ext` (predict-linear disk) and `ScrapeFailed` cover it automatically; the alert file's header count bumps six → seven.
- **Service probes**: blackbox probes for submission 587 (STARTTLS), POP3S 995, IMAPS 993, and ManageSieve 4190. An off-site port scan (2026-09-01) shows the router forwards 25/143/587/995, so those four are probed at the public edge; IMAPS 993 and ManageSieve 4190 are closed at the edge (confirmed from outside and from a cluster pod) and are probed on the internal FQDN as service checks only. Also removes the stock `pop3s_banner` module from the chart-default tail: duplicate of the new one, carrying an unescaped `^+OK` regex.
- **Mail-stack alerts** (`mail01-alerts.yaml`, ext instance):
  - `MailServiceUnitDown` — postfix@- / dovecot / opendkim / opendmarc / postgrey / spamassassin not active for 5m, via node-exporter's systemd collector (enabled by default in the Ubuntu package)
  - `MailQueueBacklog` / `MailDeferredQueueStuck` — postfix queue depth from a textfile collector installed on the host (source of truth: infra workspace `hosts/vmubt1604mail01/`)
  - `Mail01NodeExporterAbsent` — absent-only, covering the vanished-target gap `scrape-failure-alerts.yaml` documents; `ScrapeFailed` keeps the reachable-but-failing case, so no double-alerting

## Host state (already live, not tracked in this repo)

- `prometheus-node-exporter` apt-installed, serving on :9100; ufw allows 9100/tcp from the k8s node block 172.16.1.64/27 (calico `natOutgoing` SNATs scrapes to node IPs)
- `/usr/local/bin/postfix-queue-metrics.sh` + `/etc/cron.d/postfix-queue-metrics` installed (every 5m), verified emitting `postfix_queue_messages` through :9100

No merge-ordering constraint remains — the ufw rule and collector are in place, so everything scrapes green on sync.

Post-merge check: `up{job="node-exporter", instance="vmubt1604mail01.homelab.somemissing.info:9100"}` = 1 on prometheus-ext, and the four new probes at `probe_success == 1`.

## Router observation (not fixed here)

The port-forwards include POP3S 995 but not IMAPS 993 — almost certainly an oversight, since IMAPS is the more-used implicit-TLS port. If a 993 forward is added at the router, flip the `mail01-imaps-993` probe to the public name for true edge coverage.