### PR TITLE
Fix sync fallout from #551: ServiceMonitor names and PromQL escape

### DIFF
--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -74,10 +74,10 @@ spec:
             # 2026-09-01) and probed there like 25/143; IMAPS 993 and
             # ManageSieve 4190 are not forwarded, so they are probed on the
             # internal FQDN as service checks only.
-            - name: smtp.somemissing.info:587
+            - name: mail01-submission-587
               url: smtp.somemissing.info:587
               module: smtp_starttls
-            - name: imap.somemissing.info:995
+            - name: mail01-pop3s-995
               url: imap.somemissing.info:995
               module: pop3s_banner
             - name: mail01-imaps-993

--- a/mail01-alerts.yaml
+++ b/mail01-alerts.yaml
@@ -36,7 +36,7 @@ spec:
       expr: |-
         node_systemd_unit_state{
           instance="vmubt1604mail01.homelab.somemissing.info:9100",
-          name=~"(postfix@-|dovecot|opendkim|opendmarc|postgrey|spamassassin)\.service",
+          name=~"(postfix@-|dovecot|opendkim|opendmarc|postgrey|spamassassin)\\.service",
           state="active"
         } == 0
       for: 5m


### PR DESCRIPTION
#551 left both Applications in SyncError; two independent defects, both mine, one commit each:

1. **RFC 1123 ServiceMonitor names** — the blackbox chart uses each `serviceMonitor.targets[].name` as the ServiceMonitor object name, so `smtp.somemissing.info:587` / `imap.somemissing.info:995` failed k8s name validation. Renamed to `mail01-submission-587` / `mail01-pop3s-995` (matching the `mail01-imaps-993` / `mail01-sieve-4190` pair); URLs unchanged, still probing the public edge.
2. **PromQL escape in `mail01-alerts.yaml`** — `MailServiceUnitDown`'s regex used `\.service`, but PromQL string literals reject `\.` as an unknown escape; the `prometheusrulevalidate` admission webhook denied the rule and the root app's sync failed. Doubled to `\\.service`. Verified with `kubectl apply --dry-run=server`, which now passes the webhook.

Merging this restores both apps to Synced and completes the #551 rollout.