### PR TITLE
feat(mon): alert on vanished mail-stack unit series

### DIFF
--- a/mail01-alerts.yaml
+++ b/mail01-alerts.yaml
@@ -13,6 +13,10 @@
 #   documents: up == 0 cannot fire for a target that vanished from the
 #   scrape config. It is absent-only, so ScrapeFailed keeps owning the
 #   reachable-but-failing case without double-alerting.
+# - MailStackUnitSeriesAbsent covers MailServiceUnitDown's blind spot on
+#   the same vanished-series pattern: a masked or uninstalled unit
+#   exposes no node_systemd_unit_state series at all, so the
+#   state="active" == 0 check can never fire for it.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -42,6 +46,53 @@ spec:
       for: 5m
       labels:
         severity: critical
+    # No state= matcher on purpose: the alert means the unit has no series
+    # in ANY state, i.e. masked or no longer installed, which
+    # state="active" == 0 can never see. absent() alone would drop the
+    # unit label, so label_replace re-injects it and the alert text can
+    # name the vanished unit.
+    - alert: MailStackUnitSeriesAbsent
+      annotations:
+        summary: Mail-stack unit {{ $labels.unit }} on mail01 has no node_systemd_unit_state series.
+        description: >-
+          node-exporter's systemd collector exposes no
+          node_systemd_unit_state series at all for {{ $labels.unit }} on
+          vmubt1604mail01, so the unit is masked or no longer installed
+          and MailServiceUnitDown (state="active" == 0) cannot fire for a
+          vanished series. Check 'systemctl status {{ $labels.unit }}'
+          and 'systemctl list-unit-files' on the host. Motivating case:
+          the 2026-09-03 Ubuntu 22.04 to 24.04 release upgrade removed
+          the opendkim package and its postrm masked the unit, leaving
+          Postfix logging milter connect failures on every smtpd
+          connection for hours with no alert able to fire.
+      expr: |-
+        label_replace(absent(node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name="postfix@-.service"
+        }), "unit", "postfix@-.service", "", "") == 1
+        or label_replace(absent(node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name="dovecot.service"
+        }), "unit", "dovecot.service", "", "") == 1
+        or label_replace(absent(node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name="opendkim.service"
+        }), "unit", "opendkim.service", "", "") == 1
+        or label_replace(absent(node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name="opendmarc.service"
+        }), "unit", "opendmarc.service", "", "") == 1
+        or label_replace(absent(node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name="postgrey.service"
+        }), "unit", "postgrey.service", "", "") == 1
+        or label_replace(absent(node_systemd_unit_state{
+          instance="vmubt1604mail01.homelab.somemissing.info:9100",
+          name="spamassassin.service"
+        }), "unit", "spamassassin.service", "", "") == 1
+      for: 15m
+      labels:
+        severity: warning
     - alert: MailQueueBacklog
       annotations:
         summary: Postfix queue on mail01 holds over 100 messages for an hour.


### PR DESCRIPTION
## The blind spot

`MailServiceUnitDown` fires on `node_systemd_unit_state{..., state="active"} == 0`.
That expression can **never** fire for a unit that is masked or no longer
installed, because then node-exporter's systemd collector exposes no
`node_systemd_unit_state` series for it at all — the same vanished-series
blind spot `Mail01NodeExporterAbsent` already documents for scrape targets
(`up == 0` cannot fire for a target that vanished from the scrape config).

## The alert

`MailStackUnitSeriesAbsent` ORs one term per expected unit:

```
label_replace(
  absent(node_systemd_unit_state{instance="vmubt1604mail01...", name="U"}),
  "unit", "U", "", ""
) == 1
```

for U in postfix@-.service, dovecot.service, opendkim.service,
opendmarc.service, postgrey.service, spamassassin.service.

- `absent()` alone would drop the `name` label (it returns a bare `{} = 1`),
  so `label_replace` re-injects it as `unit` and the alert text can name the
  vanished unit.
- No `state=` matcher on purpose: the alert means "no series in ANY state",
  i.e. masked or uninstalled, which `state="active" == 0` can never see.
- `for: 15m`, the same vanishing-window philosophy as
  `Mail01NodeExporterAbsent`, to ride out unit transitions.

## The incident

On 2026-09-03 the Ubuntu 22.04 → 24.04 release upgrade on mail01 removed the
opendkim package and its postrm masked the unit. Postfix logged milter
connect failures on every smtpd connection for hours and no alert could
fire, because the opendkim series had simply vanished.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('mail01-alerts.yaml'))"` — OK
- `kubectl apply --dry-run=server` — accepted by the PrometheusRule admission
  webhook (the same validation that rejected `2592e93`'s invalid escape)
- pre-commit kubeconform + pluto hooks — passed