### PR TITLE
feat(jellyfin): enable Intel QuickSync HW transcoding

### DIFF
--- a/jellyfin.yaml
+++ b/jellyfin.yaml
@@ -162,6 +162,7 @@ spec:
       securityContext:
         runAsUser: 1009
         runAsGroup: 1001
+        supplementalGroups: [992]  # render group on the Intel iGPU nodes (a20-a23)
       containers:
       - name: jellyfin
         # renovate: datasource=custom.private-registry depName=registry.apps.nickv.me/jellyfin
@@ -220,9 +221,11 @@ spec:
           requests:
             memory: "1Gi"
             cpu: "10m"
+            gpu.intel.com/i915: "1"
           limits:
             memory: "4Gi"
             cpu: "2000m"
+            gpu.intel.com/i915: "1"
       volumes:
       - name: config
         persistentVolumeClaim:


### PR DESCRIPTION
## What / why

Jellyfin's Intel QuickSync HW transcoding was not working: the Deployment
requested no GPU, so the pod landed on the AMD node (a24) which has no
`/dev/dri`. This change requests `gpu.intel.com/i915: "1"` (on both `requests`
and `limits`), which pins the pod to an Intel-iGPU node (a20-a23) and makes the
intel-device-plugin inject `/dev/dri` and chown the render device to the
`runAsUser` (1009:1001). It also adds the host render group (GID 992) as
`supplementalGroups` so the non-root user can open `/dev/dri/renderD128`.

No `nodeSelector` is needed — the resource request handles placement.

## Verification

A probe using the Jellyfin image as non-root `1009:1001` requesting
`gpu.intel.com/i915: 1`:

- Auto-scheduled onto an Intel-iGPU node.
- `/dev/dri/renderD128` was chowned to `1009:1001` (mode 660) — owner access.
- The device opened successfully.
- `vainfo` reported the Intel iHD driver with full QSV decode + encode profiles.

## Follow-up (not in this PR)

The Jellyfin app config `HardwareAccelerationType` must be switched from `none`
to `qsv` (device `/dev/dri/renderD128`) via the UI or `encoding.xml` after this
merges and the pod reschedules. That config lives in the PVC, not in git.