### PR TITLE
fix(mon): clear false-positive mail01 alerts

### DIFF
--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -212,11 +212,15 @@ spec:
               timeout: 5s
               tcp:
                 tls: true
-                # Probed via the internal FQDN, which is not in the cert's
-                # SAN (smtp/imap.somemissing.info are); cert expiry stays
-                # covered by the public-edge probes on the same cert.
+                # 993 is not forwarded at the public edge, so the probe must
+                # connect by the internal FQDN — but present and verify the
+                # public name from the cert's SAN (smtp/imap.somemissing.info
+                # are). insecure_skip_verify left VerifiedChains empty, which
+                # made the exporter emit Go zero-time as
+                # probe_ssl_last_chain_expiry_timestamp_seconds and tripped
+                # CertificatesNearExpiry from 2026-09-05.
                 tls_config:
-                  insecure_skip_verify: true
+                  server_name: imap.somemissing.info
                 query_response:
                   - expect: "^\\* OK"
             pop3s_banner:

--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -231,7 +231,10 @@ spec:
               timeout: 5s
               tcp:
                 query_response:
-                  - expect: "^IMPLEMENTATION"
+                  # Banner is "IMPLEMENTATION" "Dovecot (Ubuntu)
+                  # Pigeonhole" — the leading quote defeats an
+                  # ^IMPLEMENTATION anchor; match Pigeonhole instead.
+                  - expect: "Pigeonhole"
             irc_banner:
               prober: tcp
               timeout: 5s

--- a/application.blackbox-exporter.yaml
+++ b/application.blackbox-exporter.yaml
@@ -66,9 +66,12 @@ spec:
             - name: imap.somemissing.info
               url: imap.somemissing.info:143
               module: imap_starttls
+            # Port 25 is the MX listener: AUTH was deliberately removed from
+            # it 2026-09-03 (smtpd_tls_auth_only; SASL only on 587/465), so
+            # it gets the no-AUTH variant of the STARTTLS dialogue.
             - name: smtp.somemissing.info
               url: smtp.somemissing.info:25
-              module: smtp_starttls
+              module: smtp_starttls_noauth
             # Email TLS-only listeners. Submission 587 and POP3S 995 are
             # forwarded at the public edge (verified from an external host
             # 2026-09-01) and probed there like 25/143; IMAPS 993 and
@@ -187,6 +190,22 @@ spec:
                   - starttls: true
                   - send: "EHLO prober\r"
                   - expect: "^250-AUTH"
+                  - send: "QUIT\r"
+            # Port 25 variant: postfix must not advertise AUTH there, so the
+            # post-TLS EHLO asserts a capability it always sends instead.
+            smtp_starttls_noauth:
+              prober: tcp
+              timeout: 5s
+              tcp:
+                query_response:
+                  - expect: "^220 ([^ ]+) ESMTP (.+)$"
+                  - send: "EHLO prober\r"
+                  - expect: "^250-STARTTLS"
+                  - send: "STARTTLS\r"
+                  - expect: "^220"
+                  - starttls: true
+                  - send: "EHLO prober\r"
+                  - expect: "PIPELINING"
                   - send: "QUIT\r"
             imaps_banner:
               prober: tcp

--- a/mail01-alerts.yaml
+++ b/mail01-alerts.yaml
@@ -9,6 +9,10 @@
 # - Unit-state metrics ride node-exporter's systemd collector, which the
 #   Ubuntu package enables by default; postfix runs as the instance unit
 #   postfix@-.service (postfix.service is the oneshot wrapper).
+# - Unit names are as of Ubuntu 24.04: SpamAssassin 4.0 ships the daemon as
+#   spamd.service — the jammy-era spamassassin.service vanished with the
+#   22.04 -> 24.04 upgrade (2026-09-03), so any rule still naming it fires
+#   forever.
 # - Mail01NodeExporterAbsent covers the gap scrape-failure-alerts.yaml
 #   documents: up == 0 cannot fire for a target that vanished from the
 #   scrape config. It is absent-only, so ScrapeFailed keeps owning the
@@ -34,13 +38,13 @@ spec:
         description: >-
           {{ $labels.name }} on vmubt1604mail01 reports no active state via
           node-exporter's systemd collector (covers postfix@-, dovecot,
-          opendkim, opendmarc, postgrey, and spamassassin). Check
+          opendkim, opendmarc, postgrey, and spamd). Check
           'systemctl status {{ $labels.name }}' and 'journalctl -u
           {{ $labels.name }}' on the host.
       expr: |-
         node_systemd_unit_state{
           instance="vmubt1604mail01.homelab.somemissing.info:9100",
-          name=~"(postfix@-|dovecot|opendkim|opendmarc|postgrey|spamassassin)\\.service",
+          name=~"(postfix@-|dovecot|opendkim|opendmarc|postgrey|spamd)\\.service",
           state="active"
         } == 0
       for: 5m
@@ -88,8 +92,8 @@ spec:
         }), "unit", "postgrey.service", "", "") == 1
         or label_replace(absent(node_systemd_unit_state{
           instance="vmubt1604mail01.homelab.somemissing.info:9100",
-          name="spamassassin.service"
-        }), "unit", "spamassassin.service", "", "") == 1
+          name="spamd.service"
+        }), "unit", "spamd.service", "", "") == 1
       for: 15m
       labels:
         severity: warning


### PR DESCRIPTION
Every mail01 alert that fired since 2026-09-04 is a monitoring-side
false positive — mail01 itself is healthy (queues empty, SMTP STARTTLS,
IMAPS, and ManageSieve verified live, cert valid to 2026-11-22). The
probes shipped Sep 1-2 collided with the deliberate mail01 hardening
from the same week. Four independent fixes, no host changes:

- **smtp :25** — the STARTTLS dialogue asserted `250-AUTH` post-TLS,
  but AUTH was removed from port 25 on 2026-09-03
  (`smtpd_tls_auth_only`; SASL on 587/465 only). Probe failed on every
  scrape since deployment. Port 25 now runs a no-AUTH variant; 587
  keeps the AUTH assertion.
- **sieve :4190** — Dovecot greets with `"IMPLEMENTATION" "Dovecot
  (Ubuntu) Pigeonhole"`; the leading quote defeats the
  `^IMPLEMENTATION` anchor. Matches `Pigeonhole` unanchored instead.
- **imaps :993** — `insecure_skip_verify` (added for the internal-FQDN
  target, whose name is not in the SAN) leaves VerifiedChains empty, so
  the exporter emitted Go zero-time as
  `probe_ssl_last_chain_expiry_timestamp_seconds` and
  CertificatesNearExpiry fired on a "-739,000 days" expiry. Now
  presents/verifies the SAN name via `server_name` — same internal
  connection, real chain validation (openssl `-verify_hostname`: OK).
  The public hostname can't serve this probe: 993 is not forwarded at
  the edge (SYN-blackholed, 119.5s probe).
- **spamd unit** — Ubuntu 24.04's SpamAssassin 4.0 renamed the daemon
  `spamassassin.service` → `spamd.service` (enabled, active);
  `MailStackUnitSeriesAbsent` fired continuously since 2026-09-04
  watching a unit that cannot exist.

Post-merge: Argo auto-syncs both apps; alerts should clear within one
evaluation cycle after the next scrapes (probe `for: 10m`, cert
`for: 5m`, unit-absent `for: 15m`).